### PR TITLE
Fix overlay

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -163,3 +163,4 @@ data/
 .DS_Store
 
 _version.py
+feature-overlay/

--- a/client/src/App.vue
+++ b/client/src/App.vue
@@ -3,7 +3,7 @@ import { RouterLink, RouterView } from 'vue-router'
 </script>
 
 <template>
-  <nav class="bg-gray-800 text-white p-4">
+  <!-- <nav class="bg-gray-800 text-white p-4">
     <ul class="flex justify-between">
       <div class="flex space-x-4">
         <li>
@@ -14,7 +14,7 @@ import { RouterLink, RouterView } from 'vue-router'
         </li>
       </div>
     </ul>
-  </nav>
+  </nav> -->
   <RouterView />
 </template>
 

--- a/client/src/components/LogSlider.vue
+++ b/client/src/components/LogSlider.vue
@@ -31,13 +31,24 @@ export default {
   },
   computed: {
     gain() {
-      // Enhanced logarithmic scaling to allow much lower values
-      // Scale goes from 0.001 to 10 (instead of 0.01 to 5)
-      // Using log scale: 10^(slider_position * range + min_exponent)
-      const minExponent = -3; // 10^-3 = 0.001
-      const maxExponent = 1; // 10^1 = 10
-      const range = maxExponent - minExponent;
-      const exponent = minExponent + (this.sliderValue / 100) * range;
+      // Piecewise logarithmic scaling: 0.001 to 5 in first half, 5 to 15 in second half
+      // This ensures 5 is at the middle of the slider (position 50)
+      let exponent;
+      
+      if (this.sliderValue <= 50) {
+        // First half: 0.001 to 5
+        const minExponent = -3; // log10(0.001) = -3
+        const maxExponent = Math.log10(5); // log10(5) ≈ 0.699
+        const normalizedPos = this.sliderValue / 50; // 0 to 1
+        exponent = minExponent + normalizedPos * (maxExponent - minExponent);
+      } else {
+        // Second half: 5 to 15
+        const minExponent = Math.log10(5); // log10(5) ≈ 0.699
+        const maxExponent = Math.log10(15); // log10(15) ≈ 1.176
+        const normalizedPos = (this.sliderValue - 50) / 50; // 0 to 1
+        exponent = minExponent + normalizedPos * (maxExponent - minExponent);
+      }
+      
       return Number(Math.pow(10, exponent).toFixed(6));
     },
     formattedGain() {
@@ -60,14 +71,23 @@ export default {
     },
     setGainFromOutside(newGain) {
       // Reverse calculation to set slider position from gain value
-      const minExponent = -3;
-      const maxExponent = 1;
-      const range = maxExponent - minExponent;
-      
       // Clamp the gain to our supported range
-      const clampedGain = Math.max(0.001, Math.min(10, newGain));
+      const clampedGain = Math.max(0.001, Math.min(15, newGain));
       const logGain = Math.log10(clampedGain);
-      this.sliderValue = Math.round(((logGain - minExponent) / range) * 100);
+      
+      if (clampedGain <= 5) {
+        // First half: 0.001 to 5
+        const minExponent = -3;
+        const maxExponent = Math.log10(5);
+        const normalizedPos = (logGain - minExponent) / (maxExponent - minExponent);
+        this.sliderValue = Math.round(normalizedPos * 50);
+      } else {
+        // Second half: 5 to 15
+        const minExponent = Math.log10(5);
+        const maxExponent = Math.log10(15);
+        const normalizedPos = (logGain - minExponent) / (maxExponent - minExponent);
+        this.sliderValue = Math.round(50 + normalizedPos * 50);
+      }
     },
   },
   created() {

--- a/client/src/components/LogSlider.vue
+++ b/client/src/components/LogSlider.vue
@@ -15,7 +15,6 @@
     </span>
   </div>
 </template>
-
 <script>
 export default {
   props: {
@@ -26,33 +25,28 @@ export default {
   },
   data() {
     return {
-      sliderValue: 0, // Will be set in created hook
+      sliderValue: 0,
     };
   },
   computed: {
     gain() {
-      // Piecewise logarithmic scaling: 0.001 to 5 in first half, 5 to 15 in second half
-      // This ensures 5 is at the middle of the slider (position 50)
       let exponent;
       
       if (this.sliderValue <= 50) {
-        // First half: 0.001 to 5
-        const minExponent = -3; // log10(0.001) = -3
-        const maxExponent = Math.log10(5); // log10(5) ≈ 0.699
-        const normalizedPos = this.sliderValue / 50; // 0 to 1
+        const minExponent = -3;
+        const maxExponent = Math.log10(5);
+        const normalizedPos = this.sliderValue / 50;
         exponent = minExponent + normalizedPos * (maxExponent - minExponent);
       } else {
-        // Second half: 5 to 15
-        const minExponent = Math.log10(5); // log10(5) ≈ 0.699
-        const maxExponent = Math.log10(15); // log10(15) ≈ 1.176
-        const normalizedPos = (this.sliderValue - 50) / 50; // 0 to 1
+        const minExponent = Math.log10(5);
+        const maxExponent = Math.log10(30);
+        const normalizedPos = (this.sliderValue - 50) / 50;
         exponent = minExponent + normalizedPos * (maxExponent - minExponent);
       }
       
       return Number(Math.pow(10, exponent).toFixed(6));
     },
     formattedGain() {
-      // Smart formatting based on value magnitude
       if (this.gain >= 1) {
         return this.gain.toFixed(2);
       } else if (this.gain >= 0.01) {
@@ -70,28 +64,23 @@ export default {
       this.$emit('change');
     },
     setGainFromOutside(newGain) {
-      // Reverse calculation to set slider position from gain value
-      // Clamp the gain to our supported range
-      const clampedGain = Math.max(0.001, Math.min(15, newGain));
+      const clampedGain = Math.max(0.001, Math.min(30, newGain));
       const logGain = Math.log10(clampedGain);
       
       if (clampedGain <= 5) {
-        // First half: 0.001 to 5
         const minExponent = -3;
         const maxExponent = Math.log10(5);
         const normalizedPos = (logGain - minExponent) / (maxExponent - minExponent);
         this.sliderValue = Math.round(normalizedPos * 50);
       } else {
-        // Second half: 5 to 15
         const minExponent = Math.log10(5);
-        const maxExponent = Math.log10(15);
+        const maxExponent = Math.log10(30);
         const normalizedPos = (logGain - minExponent) / (maxExponent - minExponent);
         this.sliderValue = Math.round(50 + normalizedPos * 50);
       }
     },
   },
   created() {
-    // Initialize the slider value based on the initial gain
     this.setGainFromOutside(this.initialGain);
   },
   watch: {
@@ -101,9 +90,7 @@ export default {
   }
 };
 </script>
-
 <style scoped>
-/* Enhanced slider styling */
 .slider {
   -webkit-appearance: none;
   appearance: none;
@@ -112,7 +99,6 @@ export default {
   border-radius: 3px;
   outline: none;
 }
-
 .slider::-webkit-slider-thumb {
   -webkit-appearance: none;
   appearance: none;
@@ -124,7 +110,6 @@ export default {
   cursor: pointer;
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
 }
-
 .slider::-moz-range-thumb {
   width: 16px;
   height: 16px;
@@ -135,12 +120,10 @@ export default {
   box-shadow: 0 2px 4px rgba(0,0,0,0.2);
   border: none;
 }
-
 .slider:hover::-webkit-slider-thumb {
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   transform: scale(1.1);
 }
-
 .slider:hover::-moz-range-thumb {
   box-shadow: 0 2px 8px rgba(0,0,0,0.3);
   transform: scale(1.1);

--- a/client/src/components/LogSlider.vue
+++ b/client/src/components/LogSlider.vue
@@ -32,10 +32,10 @@ export default {
   computed: {
     gain() {
       // Enhanced logarithmic scaling to allow much lower values
-      // Scale goes from 0.001 to 5 (instead of 0.01 to 5)
+      // Scale goes from 0.001 to 10 (instead of 0.01 to 5)
       // Using log scale: 10^(slider_position * range + min_exponent)
       const minExponent = -3; // 10^-3 = 0.001
-      const maxExponent = 0.699; // 10^0.699 ≈ 5
+      const maxExponent = 1; // 10^1 = 10
       const range = maxExponent - minExponent;
       const exponent = minExponent + (this.sliderValue / 100) * range;
       return Number(Math.pow(10, exponent).toFixed(6));
@@ -61,11 +61,11 @@ export default {
     setGainFromOutside(newGain) {
       // Reverse calculation to set slider position from gain value
       const minExponent = -3;
-      const maxExponent = 0.699;
+      const maxExponent = 1;
       const range = maxExponent - minExponent;
       
       // Clamp the gain to our supported range
-      const clampedGain = Math.max(0.001, Math.min(5, newGain));
+      const clampedGain = Math.max(0.001, Math.min(10, newGain));
       const logGain = Math.log10(clampedGain);
       this.sliderValue = Math.round(((logGain - minExponent) / range) * 100);
     },

--- a/client/src/lib/apiConnection.js
+++ b/client/src/lib/apiConnection.js
@@ -1,1 +1,1 @@
-export const baseUrl = process.env.NODE_ENV === "production" ? "" : "http://127.0.0.1:9000";
+export const baseUrl = process.env.NODE_ENV === "production" ? "" : "http://127.0.0.1:8000";

--- a/client/src/store/modules/slideContent.js
+++ b/client/src/store/modules/slideContent.js
@@ -70,6 +70,39 @@ export const saveDetails = async ({ state, commit }) => {
 }
 
 /**
+ * Saves only the channel settings without affecting folder or other details.
+ * @param {Object} context - Vuex context object.
+ */
+export const saveChannels = async ({ state, commit }) => {
+  // Get the current sample's existing details to preserve folder and other settings
+  let selectedSampleBuf = state.samples.filter(s => s.name === state.selectedSample.name)[0];
+  
+  let data = {
+    channelsSetting: state.activatedSample,
+    description: selectedSampleBuf.details.description || state.description,
+    overlays: selectedSampleBuf.details.overlays || state.overlays,
+    altName: selectedSampleBuf.details.altName || state.selectedSampleAltName,
+    folder: selectedSampleBuf.details.folder || "", // Preserve existing folder
+  }
+
+  const location = state.location == "public" ? "public" : (state.userProfile && state.userProfile.uid ? state.userProfile.uid : "noid");
+
+  let bufSamples = state.samples;
+  bufSamples.filter(s => s.name === state.selectedSample.name)[0].details = data;
+
+  console.log("buf samples: ", bufSamples);
+
+  commit('SET_STATE_PROPERTY', { property: "samples", value: bufSamples });
+
+  console.log("saving channels: ", data);
+
+  axios.post(`${baseUrl}/save/${location}/${state.selectedSample.name}`, data)
+    .then(response => {
+      console.log(response);
+    })
+}
+
+/**
  * Deletes an overlay from the current state.
  * @param {Object} context - Vuex context object.
  * @param {number} index - The index of the overlay to delete.

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -668,108 +668,123 @@ export default {
     },
     
     processCSV(csvContent, fileName) {
-      // Simple CSV parsing
-      const lines = csvContent.split('\n');
-      const headers = lines[0].split(',');
-      
-      // Expected headers: x, y, description (optional)
-      const xIndex = headers.findIndex(h => h.toLowerCase().trim() === 'x');
-      const yIndex = headers.findIndex(h => h.toLowerCase().trim() === 'y');
-      const labelIndex = headers.findIndex(h => h.toLowerCase().trim() === 'label' || h.toLowerCase().trim() === 'description');
-      
-      if (xIndex === -1 || yIndex === -1) {
-        alert("CSV file must contain columns for 'x' and 'y' coordinates");
-        return;
+  // Simple CSV parsing
+  const lines = csvContent.split('\n');
+  const headers = lines[0].split(',');
+  
+  // Expected headers: x, y, description (optional)
+  const xIndex = headers.findIndex(h => h.toLowerCase().trim() === 'x');
+  const yIndex = headers.findIndex(h => h.toLowerCase().trim() === 'y');
+  const labelIndex = headers.findIndex(h => h.toLowerCase().trim() === 'label' || h.toLowerCase().trim() === 'description');
+  
+  if (xIndex === -1 || yIndex === -1) {
+    alert("CSV file must contain columns for 'x' and 'y' coordinates");
+    return;
+  }
+  
+  // Collect all unique labels and assign colors
+  const uniqueLabels = new Set();
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const values = lines[i].split(',');
+    if (labelIndex !== -1 && values[labelIndex]) {
+      uniqueLabels.add(values[labelIndex].trim());
+    }
+  }
+  
+  // Generate a color map for each unique label
+  const colorMap = this.generateColorMap(Array.from(uniqueLabels));
+  
+  const pointOverlays = [];
+  
+  // Check coordinate scale - find max values
+  let maxX = 0, maxY = 0;
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    const values = lines[i].split(',');
+    const x = parseFloat(values[xIndex]);
+    const y = parseFloat(values[yIndex]);
+    if (!isNaN(x) && !isNaN(y)) {
+      maxX = Math.max(maxX, x);
+      maxY = Math.max(maxY, y);
+    }
+  }
+  
+  console.log(`Coordinate ranges - X: 0-${maxX}, Y: 0-${maxY}`);
+  
+  // Determine if coordinates are already normalized (0-1 range)
+  const isNormalized = maxX <= 1 && maxY <= 1;
+  console.log(`Coordinates are ${isNormalized ? 'already normalized' : 'in pixel space'}`);
+  
+  // Get image dimensions if needed
+  let imageWidth = 1, imageHeight = 1;
+  if (!isNormalized) {
+    if (!this.viewer || this.viewer.world.getItemCount() === 0) {
+      alert("Cannot normalize coordinates: No image is currently loaded.");
+      return;
+    }
+    imageWidth = this.viewer.world.getItemAt(0).source.dimensions.x;
+    imageHeight = this.viewer.world.getItemAt(0).source.dimensions.y;
+    console.log(`Normalizing using image dimensions: ${imageWidth}x${imageHeight}`);
+  }
+  
+  // Get the aspect ratio for OpenSeadragon viewport coordinates
+  let aspectRatio = 1;
+  if (this.viewer && this.viewer.world.getItemCount() > 0) {
+    const tiledImage = this.viewer.world.getItemAt(0);
+    aspectRatio = tiledImage.source.dimensions.x / tiledImage.source.dimensions.y;
+    console.log(`Image aspect ratio: ${aspectRatio}`);
+  }
+  
+  // Process data rows
+  for (let i = 1; i < lines.length; i++) {
+    if (!lines[i].trim()) continue;
+    
+    const values = lines[i].split(',');
+    let x = parseFloat(values[xIndex]);
+    let y = parseFloat(values[yIndex]);
+    const label = labelIndex !== -1 ? values[labelIndex].trim() : `Point ${i}`;
+    
+    if (!isNaN(x) && !isNaN(y)) {
+      // Normalize if in pixel space
+      if (!isNormalized) {
+        x = x / imageWidth;
+        y = y / imageHeight;
       }
       
-      // Collect all unique labels and assign colors
-      const uniqueLabels = new Set();
-      for (let i = 1; i < lines.length; i++) {
-        if (!lines[i].trim()) continue; // Skip empty lines
-        const values = lines[i].split(',');
-        if (labelIndex !== -1 && values[labelIndex]) {
-          uniqueLabels.add(values[labelIndex].trim());
-        }
-      }
+      // Convert to OpenSeadragon viewport coordinates
+      // In OSD, x ranges from 0 to 1, and y ranges from 0 to 1/aspectRatio
+      const osdX = x;
+      const osdY = y / aspectRatio;
       
-      // Generate a color map for each unique label
-      const colorMap = this.generateColorMap(Array.from(uniqueLabels));
-      
-      const pointOverlays = [];
-      
-      // First pass to check coordinate scale
-      let needsNormalization = false;
-      
-      for (let i = 1; i < lines.length; i++) {
-        if (!lines[i].trim()) continue; // Skip empty lines
-        
-        const values = lines[i].split(',');
-        const x = parseFloat(values[xIndex]);
-        const y = parseFloat(values[yIndex]);
-        
-        if (!isNaN(x) && !isNaN(y)) {
-          // If we find coordinates > 1, they're likely in actual image coordinates
-          if (x > 1 || y > 1) {
-            needsNormalization = true;
-            break;
-          }
-        }
-      }
-
-      console.log(`Needs normalization: ${needsNormalization}`);
-      
-      // Get image dimensions if available and needed
-      let imageWidth = 1, imageHeight = 1;
-      if (needsNormalization) {
-        if (!this.viewer || this.viewer.world.getItemCount() === 0) {
-          alert("Cannot normalize coordinates: No image is currently loaded. Please load an image first.");
-          return;
-        }
-        
-        imageWidth = this.viewer.world.getItemAt(0).source.dimensions.x;
-        imageHeight = this.viewer.world.getItemAt(0).source.dimensions.y; 
-        console.log(`Normalizing coordinates using image dimensions: ${imageWidth}x${imageHeight}`);
-      }
-      
-      // Skip header row, process data rows
-      for (let i = 1; i < lines.length; i++) {
-        if (!lines[i].trim()) continue; // Skip empty lines
-        
-        const values = lines[i].split(',');
-        let x = parseFloat(values[xIndex]);
-        let y = parseFloat(values[yIndex]);
-        const label = labelIndex !== -1 ? values[labelIndex].trim() : `Point ${i}`;
-        
-        if (!isNaN(x) && !isNaN(y)) {
-          // Normalize coordinates if needed
-          if (needsNormalization) {
-            x = x / imageWidth;
-            y = y / imageHeight;
-          }
-          
-          pointOverlays.push({
-            location: {
-              x: x,
-              y: y
-            },
-            description: label,
-            color: colorMap[label] || '#FF0000', // Default to red if no color found
-          });
-        }
-      }
-      
-      // Add to overlay files list
-      const newOverlayFile = {
-        id: Date.now().toString(),
-        name: fileName,
-        data: pointOverlays,
-        colorMap: colorMap
-      };
-      
-      this.overlayFiles.push(newOverlayFile);
-      this.selectedOverlayFile = newOverlayFile.id;
-      this.displayPointOverlays(pointOverlays);
-    },
+      pointOverlays.push({
+        location: {
+          x: osdX,
+          y: osdY
+        },
+        description: label,
+        color: colorMap[label] || '#FF0000',
+      });
+    }
+  }
+  
+  console.log(`Processed ${pointOverlays.length} points`);
+  if (pointOverlays.length > 0) {
+    console.log(`First point: (${pointOverlays[0].location.x}, ${pointOverlays[0].location.y})`);
+  }
+  
+  // Add to overlay files list
+  const newOverlayFile = {
+    id: Date.now().toString(),
+    name: fileName,
+    data: pointOverlays,
+    colorMap: colorMap
+  };
+  
+  this.overlayFiles.push(newOverlayFile);
+  this.selectedOverlayFile = newOverlayFile.id;
+  this.displayPointOverlays(pointOverlays);
+},
     
     loadSelectedOverlay() {
       if (!this.selectedOverlayFile) return;

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -342,12 +342,20 @@ export default {
       },
       filteredSamples() {
         // If "Any" ('') is selected, return all samples; otherwise, filter by folder
+        let filtered = [];
         if (!this.selectedFolder) {
-          return this.samples;
+          filtered = this.samples;
+        } else {
+          filtered = this.samples.filter(
+            sample => sample.details && sample.details.folder === this.selectedFolder
+          );
         }
-        return this.samples.filter(
-          sample => sample.details && sample.details.folder === this.selectedFolder
-        );
+        // Sort alphabetically by display name (altName if available, otherwise name)
+        return filtered.sort((a, b) => {
+          const nameA = (a.details && a.details.altName) ? a.details.altName : a.name;
+          const nameB = (b.details && b.details.altName) ? b.details.altName : b.name;
+          return nameA.localeCompare(nameB);
+        });
       },
       activeOverlayLegend() {
         // If no overlay file is selected, return null

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -146,6 +146,7 @@
               </div>
             </div>
           </div>
+          <button class="mt-2 p-2 bg-blue-600 hover:bg-blue-700 text-white rounded" @click="saveChannels">Save channels</button>
         </div>
 
         <div class="mb-4">
@@ -495,7 +496,7 @@ export default {
     },
   },
   methods: {
-    ...mapActions(["loadSampleSheet", "loadSample", "reloadSlide", "saveDetails", "addStain", "removeStain", "deleteOverlay", "copySettings"]),
+    ...mapActions(["loadSampleSheet", "loadSample", "reloadSlide", "saveDetails", "saveChannels", "addStain", "removeStain", "deleteOverlay", "copySettings"]),
     ...mapMutations(["SET_STATE_PROPERTY"]),
     copyLinkToClipboard() {
       const baseUrl = `${window.location.origin}${window.location.pathname}`;

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -59,9 +59,6 @@
       <button class="p-2" @click="copyLinkToClipboard">
         <share-icon class="icon" />
       </button>
-      <button class="p-2" @click="saveDetails">
-          <archive-box-icon class="icon" />
-      </button>
       <button class="p-2" @click="windowMinimal = !windowMinimal">
         <div v-if="windowMinimal">
           <plus-circle-icon class="icon" />
@@ -277,7 +274,7 @@
 import OpenSeadragon from "openseadragon";
 import { mapGetters, mapActions, mapState, mapMutations } from "vuex";
 
-import { BeakerIcon, MinusCircleIcon, PlusCircleIcon, ArchiveBoxIcon, 
+import { BeakerIcon, MinusCircleIcon, PlusCircleIcon, 
   XCircleIcon, ShareIcon } from '@heroicons/vue/24/solid'
 
 import LogSlider from "../components/LogSlider.vue";
@@ -287,7 +284,6 @@ export default {
     BeakerIcon, 
     MinusCircleIcon,
     PlusCircleIcon,
-    ArchiveBoxIcon,
     XCircleIcon,
     ShareIcon,
     LogSlider,

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -189,6 +189,32 @@
           <div class="mb-2 text-white text-xs">
             <p>CSV Format: Header row with columns 'x', 'y', and 'label' (or 'description')</p>
           </div>
+
+          <!-- Overlay scaling controls -->
+          <div class="flex space-x-2 mb-2">
+            <div class="flex-1">
+              <label class="text-white text-xs block">X factor</label>
+              <input
+                type="number"
+                step="0.01"
+                v-model.number="overlayScaleX"
+                @change="applyOverlayScale"
+                class="block w-full mt-1 pl-2 pr-2 py-1 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md"
+                placeholder="1"
+              />
+            </div>
+            <div class="flex-1">
+              <label class="text-white text-xs block">Y factor</label>
+              <input
+                type="number"
+                step="0.01"
+                v-model.number="overlayScaleY"
+                @change="applyOverlayScale"
+                class="block w-full mt-1 pl-2 pr-2 py-1 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md"
+                placeholder="1"
+              />
+            </div>
+          </div>
           
           <div class="flex items-center space-x-2 mb-2">
             <input
@@ -283,6 +309,8 @@ export default {
       selectedFolder: "",
       selectedSampleFolderDropdown: "",
       copySettingsFromSample: "",
+      overlayScaleX: 1,
+      overlayScaleY: 1,
     }
   },
   computed: {
@@ -747,9 +775,26 @@ export default {
       this.displayPointOverlays(overlay.data);
     },
 
+    applyOverlayScale() {
+      const overlay = this.overlayFiles.find(o => o.id === this.selectedOverlayFile);
+      if (!overlay) {
+        return;
+      }
+      this.displayPointOverlays(overlay.data);
+    },
+
     displayPointOverlays(points) {
-      // Store all point overlays for filtering later
-      this.allPointOverlays = points;
+      // Store all point overlays for filtering later with scaling applied
+      const scaleX = Number.isFinite(this.overlayScaleX) ? this.overlayScaleX : 1;
+      const scaleY = Number.isFinite(this.overlayScaleY) ? this.overlayScaleY : 1;
+
+      this.allPointOverlays = points.map(point => ({
+        ...point,
+        location: {
+          x: point.location.x * scaleX,
+          y: point.location.y * scaleY,
+        },
+      }));
       
       // Clear any existing point overlays first
       this.clearPointOverlays();

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -715,6 +715,8 @@ export default {
           }
         }
       }
+
+      console.log("Needs normalization: ${needsNormalization}")
       
       // Get image dimensions if available and needed
       let imageWidth = 1, imageHeight = 1;

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -39,8 +39,8 @@
 <!-- END HUD -->
 
 <!-- MINIMIZED -->
-<div id="minimized-menu" class="rounded text-gray-800 bg-gray-600" v-if="windowMinimal">
-  <div class="flex p-4">
+<div id="minimized-menu" class="rounded text-gray-800" v-if="windowMinimal">
+  <div class="flex justify-end p-4">
     <button class="p-2" @click="windowMinimal = !windowMinimal">
       <plus-circle-icon class="icon" />
     </button>
@@ -964,7 +964,7 @@ div#view {
 #minimized-menu {
   z-index: 1000;
   position: fixed;
-  top: 10vh;
+  top: 1vh;
   right: 1vw;
   width: 5vw;
   max-height: 10vh;
@@ -974,10 +974,10 @@ div#view {
 #navigation-menu {
   z-index: 1000;
   position: fixed;
-  top: 10vh;
+  top: 1vh;
   right: 1vw;
   width: 25vw;
-  max-height: 90vh;
+  max-height: 98vh;
   overflow-y: auto;
 }
 </style>

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -716,7 +716,7 @@ export default {
         }
       }
 
-      console.log("Needs normalization: ${needsNormalization}")
+      console.log(`Needs normalization: ${needsNormalization}`);
       
       // Get image dimensions if available and needed
       let imageWidth = 1, imageHeight = 1;

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -536,7 +536,54 @@ export default {
         zoomPerScroll: 2,
         showNavigationControl: true,
         navigationControlAnchor: OpenSeadragon.ControlAnchor.TOP_LEFT,
+
+        imageLoaderLimit: 2,          // Only 2 concurrent tile requests
+        immediateRender: false,       // Wait before rendering
+        placeholderFillStyle: '#000', // Black placeholder while loading
+        
       });
+      // start speedup
+      let scrollTimeout = null;
+      let wasPaused = false;
+
+      const pauseLoading = () => {
+        if (!wasPaused && this.viewer.world.getItemCount() > 0) {
+          // Freeze all tiled images to stop requesting new tiles
+          for (let i = 0; i < this.viewer.world.getItemCount(); i++) {
+            this.viewer.world.getItemAt(i).setPreload(false);
+          }
+          wasPaused = true;
+        }
+      };
+
+      const resumeLoading = () => {
+        if (wasPaused && this.viewer.world.getItemCount() > 0) {
+          for (let i = 0; i < this.viewer.world.getItemCount(); i++) {
+            this.viewer.world.getItemAt(i).setPreload(true);
+          }
+          wasPaused = false;
+          // Force a redraw to load visible tiles
+          this.viewer.forceRedraw();
+        }
+      };
+
+      this.viewer.addHandler('canvas-scroll', () => {
+        pauseLoading();
+        clearTimeout(scrollTimeout);
+        scrollTimeout = setTimeout(resumeLoading, 400); // Resume 400ms after scroll stops
+      });
+
+      this.viewer.addHandler('canvas-drag', () => {
+        pauseLoading();
+        clearTimeout(scrollTimeout);
+        scrollTimeout = setTimeout(resumeLoading, 400);
+      });
+
+      this.viewer.addHandler('canvas-drag-end', () => {
+        clearTimeout(scrollTimeout);
+        scrollTimeout = setTimeout(resumeLoading, 200);
+      });
+      // end speed
 
       // Add handlers for viewport changes to update point overlays
       this.viewer.addHandler('animation', () => {

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -1,16 +1,13 @@
 <template>
  <div class="flex min-h-screen">
-
 <!-- OVERLAY -->
 <div id="right-arrow-overlay" hidden>
   <span class="text-2xl text-white">&rarr;</span>
 </div>
-
 <!-- VIEW -->
 <div id="view" class="w-full h-full relative">
   <div v-if="!hasActiveChannels" id="viewEmpty" class="absolute inset-0 bg-black z-10"></div>
 </div>
-
 <!-- HUD -->
 <div id="hud" class="fixed bottom-5 left-5 max-w-60 max-h-60 overflow-y-auto bg-black bg-opacity-70 p-2 rounded-md text-white" v-if="activatedSampleLocal && activatedSampleLocal.length > 1 || activeOverlayLegend">
   <div v-if="activatedSampleLocal && activatedSampleLocal.length > 1">
@@ -37,7 +34,6 @@
   </div>
 </div>
 <!-- END HUD -->
-
 <!-- MINIMIZED -->
 <div id="minimized-menu" class="rounded text-gray-800" v-if="windowMinimal">
   <div class="flex justify-end p-4">
@@ -46,9 +42,7 @@
     </button>
   </div>
 </div>
-
 <!-- END MINIMIZED -->
-
 <!-- NAVIGATION -->
 <div id="navigation-menu" class="rounded text-gray-800 bg-gray-600" v-if="!windowMinimal">
   <div class="flex items-center justify-between p-4">
@@ -77,7 +71,6 @@
       </select>
     </div>
   </div>
-
   <div class="px-4">
     <div class="mb-4">
       <strong class="text-white">Select folder</strong>
@@ -86,7 +79,6 @@
       </select>
     </div>
   </div>
-
   <!-- IF LOADING -->
   <div v-if="!filteredSamples.length" class="p-4">
     <div class="flex justify-center">
@@ -94,7 +86,6 @@
     </div>
   </div>
   <!-- IF NOT LOADING -->
-
   <div v-else class="px-4">
     <div class="mb-4">
       <strong class="text-white">Select slide</strong>
@@ -104,16 +95,14 @@
       <!-- add text field to add alternative name to slide -->
       <input type="text" v-model="selectedSampleAltNameLocal" class="block w-full mt-1 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md" placeholder="Alternative name">
       <button class="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded" @click="saveDetails">Rename</button>
-      <!-- add move to folder options, add a dropdown to select the folder or create a new folder with textbox-->
+      <!-- add move to folder options -->
       <select v-model="selectedSampleFolderDropdown" class="block w-full mt-1 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md">
         <option v-for="folder in folders" :value="folder.key">{{ folder.name }}</option>
       </select>
       <input type="text" v-model="newFolderName" class="block w-full mt-1 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md" placeholder="or create a new folder">
       <button class="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded" @click="addToFolder">Add to folder</button>
     </div>
-    <!-- IF WINDOW NOT MINIMIZED -->
-    <!-- <div v-if="!windowMinimal"> -->
-      <!-- <div v-if="selectedSample.files.length > 1"> -->
+
         <div class="mb-4">
           <strong class="text-white">Channels</strong>
           <div v-for="channel in activatedSampleLocal" :key="channel.channel_number">
@@ -128,31 +117,24 @@
                 <select v-model="channel.stain" class="flex-grow p-1 border rounded" @change="settingsChanged">
                   <option v-for="option in colorOptions" :value="option">{{ option }}</option>
                 </select>
-
                 <input type="checkbox" v-model="channel.activated" @change="settingsChanged">
-
-                <!-- <input type="range" v-model="channel.gain" max="5" min="0" step="0.01" class="flex-grow" @change="settingsChanged"> -->
-                 
                 <log-slider
                   :initial-gain="channel.gain"
                   v-model:gain="channel.gain"
                   @change="settingsChanged"
                   class="flex-grow"
                 />
-              
               </div>
             </div>
           </div>
           <button class="mt-2 p-2 bg-blue-600 hover:bg-blue-700 text-white rounded" @click="saveChannels">Save channels</button>
         </div>
-
         <div class="mb-4">
           <strong class="text-white">Add channel</strong>
           <select v-model="addStainFileLocal" class="block w-full mt-1 pl-3 pr-10 py-2 text-base border-gray-300 focus:outline-none focus:ring-primary focus:border-primary sm:text-sm rounded-md" @change="addStain">
             <option v-for="option in activatedSample" :value="option.channel_number">{{ option.channel_name }}</option>
           </select>
         </div>
-
         <!-- copy settings from another slide -->
         <div class="mb-4">
           <strong class="text-white">Copy settings from another slide</strong>
@@ -161,6 +143,82 @@
           </select>
         </div>
         <button class="p-2 bg-blue-600 hover:bg-blue-700 text-white rounded" @click="copySettingsLocal">Copy settings</button>
+
+      <!-- ROTATION & FLIP CONTROLS -->
+      <div class="mb-4 mt-4">
+        <strong class="text-white">Transform</strong>
+        <div class="mt-2 p-2 border rounded bg-gray-700">
+          <!-- Quick rotation buttons -->
+          <div class="flex items-center space-x-2 mb-2">
+            <button class="p-2 bg-gray-500 hover:bg-gray-400 text-white rounded text-sm" @click="rotateBy(-90)" title="Rotate 90° left">
+              ↺ 90°
+            </button>
+            <button class="p-2 bg-gray-500 hover:bg-gray-400 text-white rounded text-sm" @click="rotateBy(90)" title="Rotate 90° right">
+              ↻ 90°
+            </button>
+            <button class="p-2 bg-gray-500 hover:bg-gray-400 text-white rounded text-sm" @click="rotateBy(180)" title="Rotate 180°">
+              180°
+            </button>
+            <button class="p-2 bg-gray-500 hover:bg-gray-400 text-white rounded text-sm" @click="resetTransform" title="Reset">
+              Reset
+            </button>
+          </div>
+
+          <!-- Fine-grained rotation slider -->
+          <div class="mb-2">
+            <label class="text-white text-xs block mb-1">Rotation: {{ rotationAngle }}°</label>
+            <input
+              type="range"
+              v-model.number="rotationAngle"
+              min="0"
+              max="359"
+              step="1"
+              class="w-full h-2 bg-gray-300 rounded-lg appearance-none cursor-pointer"
+              @input="applyRotation"
+            />
+            <div class="flex items-center space-x-2 mt-1">
+              <input
+                type="number"
+                v-model.number="rotationAngle"
+                min="0"
+                max="359"
+                step="0.1"
+                class="w-20 p-1 text-sm border rounded text-gray-800"
+                @change="applyRotation"
+              />
+              <span class="text-white text-xs">degrees</span>
+              <!-- Fine adjustment buttons -->
+              <button class="px-2 py-1 bg-gray-500 hover:bg-gray-400 text-white rounded text-xs" @click="rotateBy(-1)">-1°</button>
+              <button class="px-2 py-1 bg-gray-500 hover:bg-gray-400 text-white rounded text-xs" @click="rotateBy(1)">+1°</button>
+              <button class="px-2 py-1 bg-gray-500 hover:bg-gray-400 text-white rounded text-xs" @click="rotateBy(-0.1)">-0.1°</button>
+              <button class="px-2 py-1 bg-gray-500 hover:bg-gray-400 text-white rounded text-xs" @click="rotateBy(0.1)">+0.1°</button>
+            </div>
+          </div>
+
+          <!-- Flip controls -->
+          <div class="flex items-center space-x-3 mt-2">
+            <label class="flex items-center cursor-pointer">
+              <div class="relative">
+                <input type="checkbox" v-model="flipHorizontal" class="sr-only" @change="applyFlip">
+                <div class="block bg-gray-600 w-10 h-6 rounded-full"></div>
+                <div class="dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition"
+                     :class="{'transform translate-x-4': flipHorizontal}"></div>
+              </div>
+              <span class="ml-2 text-white text-sm">Flip H</span>
+            </label>
+            <label class="flex items-center cursor-pointer">
+              <div class="relative">
+                <input type="checkbox" v-model="flipVertical" class="sr-only" @change="applyFlip">
+                <div class="block bg-gray-600 w-10 h-6 rounded-full"></div>
+                <div class="dot absolute left-1 top-1 bg-white w-4 h-4 rounded-full transition"
+                     :class="{'transform translate-x-4': flipVertical}"></div>
+              </div>
+              <span class="ml-2 text-white text-sm">Flip V</span>
+            </label>
+          </div>
+        </div>
+      </div>
+      <!-- END ROTATION & FLIP CONTROLS -->
 
       <div class="mb-4">
         <strong class="text-white">Annotations</strong>
@@ -187,7 +245,6 @@
           <div class="mb-2 text-white text-xs">
             <p>CSV Format: Header row with columns 'x', 'y', and 'label' (or 'description')</p>
           </div>
-
           <!-- Overlay scaling controls -->
           <div class="flex space-x-2 mb-2">
             <div class="flex-1">
@@ -263,22 +320,17 @@
           </div>
         </div>
       </div>
-    <!-- </div> -->
   </div>
 </div>
 <!-- END NAVIGATION -->
 </div>
 </template>
-
 <script>
 import OpenSeadragon from "openseadragon";
 import { mapGetters, mapActions, mapState, mapMutations } from "vuex";
-
 import { BeakerIcon, MinusCircleIcon, PlusCircleIcon, 
   XCircleIcon, ShareIcon } from '@heroicons/vue/24/solid'
-
 import LogSlider from "../components/LogSlider.vue";
-
 export default {
   components: {
     BeakerIcon, 
@@ -297,17 +349,21 @@ export default {
       overlayFiles: [],
       selectedOverlayFile: "",
       mouseTrackerInitialized: false,
-      maxVisiblePoints: 250,         // Maximum number of points to display at once
-      currentPointOverlays: [],      // Currently displayed point overlays
-      allPointOverlays: [],          // All point overlays from the CSV
-      viewportUpdateTimeout: null,   // For debouncing viewport changes
-      showPointOverlays: true,       // Toggle for showing/hiding point overlays
+      maxVisiblePoints: 250,
+      currentPointOverlays: [],
+      allPointOverlays: [],
+      viewportUpdateTimeout: null,
+      showPointOverlays: true,
       newFolderName: "",
       selectedFolder: "",
       selectedSampleFolderDropdown: "",
       copySettingsFromSample: "",
       overlayScaleX: 1,
       overlayScaleY: 1,
+      // Transform controls
+      rotationAngle: 0,
+      flipHorizontal: false,
+      flipVertical: false,
     }
   },
   computed: {
@@ -317,7 +373,6 @@ export default {
       "saveEnabled", "activatedStains", "activatedSample", "location", "selectedSampleAltName", 
       "selectedSampleFolder"]),
       folders() {
-        // Collect unique folders from all samples
         const folderSet = new Set();
         this.samples.forEach(sample => {
           if (
@@ -328,20 +383,16 @@ export default {
             folderSet.add(sample.details.folder);
           }
         });
-        // Convert set to array of { name, key }
         const foldersList = Array.from(folderSet).map(folder => ({
           name: folder,
           key: folder
         }));
-
-        // Always put "Any" at the top
         return [...foldersList];
       },
       foldersWithAny() {
         return [{ name: '-', key: '' }, ...this.folders];
       },
       filteredSamples() {
-        // If "Any" ('') is selected, return all samples; otherwise, filter by folder
         let filtered = [];
         if (!this.selectedFolder) {
           filtered = this.samples;
@@ -350,7 +401,6 @@ export default {
             sample => sample.details && sample.details.folder === this.selectedFolder
           );
         }
-        // Sort alphabetically by display name (altName if available, otherwise name)
         return filtered.sort((a, b) => {
           const nameA = (a.details && a.details.altName) ? a.details.altName : a.name;
           const nameB = (b.details && b.details.altName) ? b.details.altName : b.name;
@@ -358,17 +408,11 @@ export default {
         });
       },
       activeOverlayLegend() {
-        // If no overlay file is selected, return null
         if (!this.selectedOverlayFile) return null;
-        
-        // Find the selected overlay file
         const overlay = this.overlayFiles.find(o => o.id === this.selectedOverlayFile);
         if (!overlay) return null;
-        
-        // Return the color map from the selected overlay file
         return overlay.colorMap;
       },
-
       hasActiveChannels() {
         return this.activatedSampleLocal.filter(sample => (sample.stain !== "empty" && sample.activated)).length > 0;
       },
@@ -444,7 +488,6 @@ export default {
         this.SET_STATE_PROPERTY({ property: "addStainFile", value: value });
       },
     },
-
     selectedSampleNameLocal: {
       get() {
         return this.selectedSampleName;
@@ -483,16 +526,15 @@ export default {
       this.loadSampleSheet();
     },
     selectedSampleNameLocal: function () {
+      this.resetTransform();
       this.loadSample();
     },
     currentSlideLocal: function (newValue, oldValue) {
       console.log("changed current slide to: ", newValue);
-
       this.viewer.open(newValue);
       for (let i = 0; i < this.overlaysLocal.length; i++) {
         this.addOverlay(this.overlaysLocal[i].location.x, this.overlaysLocal[i].location.y, this.overlaysLocal[i].number, this.overlaysLocal[i].description);
       }
-
     }, 
     overlaysLocal: function(newValue, oldValue) {
       console.log("overlays changed");
@@ -525,94 +567,76 @@ export default {
       this.viewer = new OpenSeadragon({
         id: "view",
         prefixUrl: "images/",
-        timeout: 120000, //120000
-        animationTime: 1, //0.5
-        blendTime: 0.5, //0.1
+        timeout: 120000,
+        animationTime: 1,
+        blendTime: 0.5,
         showRotationControl: true,
         constrainDuringPan: true,
-        maxZoomPixelRatio: 3, //2
+        maxZoomPixelRatio: 3,
         minZoomImageRatio: 1,
         visibilityRatio: 1,
         zoomPerScroll: 2,
         showNavigationControl: true,
         navigationControlAnchor: OpenSeadragon.ControlAnchor.TOP_LEFT,
-
-        imageLoaderLimit: 2,          // Only 2 concurrent tile requests
-        immediateRender: false,       // Wait before rendering
-        placeholderFillStyle: '#000', // Black placeholder while loading
-        
+        imageLoaderLimit: 2,
+        immediateRender: false,
+        placeholderFillStyle: '#000',
       });
       // start speedup
       let scrollTimeout = null;
       let wasPaused = false;
-
       const pauseLoading = () => {
         if (!wasPaused && this.viewer.world.getItemCount() > 0) {
-          // Freeze all tiled images to stop requesting new tiles
           for (let i = 0; i < this.viewer.world.getItemCount(); i++) {
             this.viewer.world.getItemAt(i).setPreload(false);
           }
           wasPaused = true;
         }
       };
-
       const resumeLoading = () => {
         if (wasPaused && this.viewer.world.getItemCount() > 0) {
           for (let i = 0; i < this.viewer.world.getItemCount(); i++) {
             this.viewer.world.getItemAt(i).setPreload(true);
           }
           wasPaused = false;
-          // Force a redraw to load visible tiles
           this.viewer.forceRedraw();
         }
       };
-
       this.viewer.addHandler('canvas-scroll', () => {
         pauseLoading();
         clearTimeout(scrollTimeout);
-        scrollTimeout = setTimeout(resumeLoading, 400); // Resume 400ms after scroll stops
+        scrollTimeout = setTimeout(resumeLoading, 400);
       });
-
       this.viewer.addHandler('canvas-drag', () => {
         pauseLoading();
         clearTimeout(scrollTimeout);
         scrollTimeout = setTimeout(resumeLoading, 400);
       });
-
       this.viewer.addHandler('canvas-drag-end', () => {
         clearTimeout(scrollTimeout);
         scrollTimeout = setTimeout(resumeLoading, 200);
       });
-      // end speed
-
+      // end speedup
       // Add handlers for viewport changes to update point overlays
       this.viewer.addHandler('animation', () => {
-        // Use debouncing to prevent too frequent updates during continuous operations
         clearTimeout(this.viewportUpdateTimeout);
         this.viewportUpdateTimeout = setTimeout(() => {
           if (this.allPointOverlays && this.allPointOverlays.length) {
             this.updateVisiblePoints();
           }
-        }, 200); // 200ms debounce
+        }, 200);
       });
-
       this.viewer.addHandler('tile-drawn', () => {
         if (!this.mouseTrackerInitialized) {
           this.mouseTrackerInitialized = true;
-
           this.$nextTick(() => {
-
             new OpenSeadragon.MouseTracker({
               element: this.viewer.canvas,
               contextMenuHandler: e => {
                 e.originalEvent.preventDefault();
                 const clickPosition = e.position;
-
-                // Convert the click position to image coordinates
                 const imageCoordinates = this.viewer.viewport.viewerElementToImageCoordinates(clickPosition);
-
                 const elementCoordiantes = this.viewer.viewport.imageToViewportCoordinates(imageCoordinates);
-
                 this.overlaysLocal.push({
                   location: {
                     x: elementCoordiantes.x,
@@ -621,85 +645,112 @@ export default {
                   description: "",
                   number: this.overlaysLocal.length > 0 ? this.overlaysLocal.map(overlay => overlay.number).sort((a, b) => a - b)[this.overlaysLocal.length - 1] + 1 : 1
                 });
-
                 console.log(this.overlaysLocal);
-
-                //Add overlay, disabled for now
                 this.addOverlay(elementCoordiantes.x, elementCoordiantes.y, this.overlaysLocal[this.overlaysLocal.length - 1].number, this.overlaysLocal[this.overlaysLocal.length - 1].description);
               },
             });
           });
         }
       });
-
       this.viewer.addHandler('open', () => {
         this.setBounds();
       });
-
+      // Sync rotation angle when OSD built-in rotation control is used
+      this.viewer.addHandler('rotate', (event) => {
+        this.rotationAngle = parseFloat((this.viewer.viewport.getRotation() % 360).toFixed(1));
+        if (this.rotationAngle < 0) this.rotationAngle += 360;
+      });
     },
-
     reloadOverlays() {
       this.viewer.clearOverlays();
       for (let i = 0; i < this.overlaysLocal.length; i++) {
         this.addOverlay(this.overlaysLocal[i].location.x, this.overlaysLocal[i].location.y, this.overlaysLocal[i].number, this.overlaysLocal[i].description);
       }
     },
-
     settingsChanged() {
       console.log("settings changed");
       this.getBounds();
       this.reloadSlide();
     },
-
     setBounds() {
       if (this.viewportBoundsLocal) {
         console.log("setting viewport to: ", this.viewportBoundsLocal);
         this.viewer.viewport.fitBounds(this.viewportBoundsLocal, true);
       }
     },
-
     getBounds() {
       this.viewportBoundsLocal = this.viewer.viewport.getBounds();
-
       console.log("viewport bounds: ", this.viewportBoundsLocal);
     },
-
+    // --- ROTATION & FLIP METHODS ---
+    applyRotation() {
+      if (!this.viewer) return;
+      const angle = parseFloat(this.rotationAngle) || 0;
+      this.viewer.viewport.setRotation(angle);
+    },
+    rotateBy(degrees) {
+      if (!this.viewer) return;
+      this.rotationAngle = parseFloat(((this.rotationAngle + degrees) % 360).toFixed(1));
+      if (this.rotationAngle < 0) this.rotationAngle += 360;
+      this.viewer.viewport.setRotation(this.rotationAngle);
+    },
+    applyFlip() {
+      if (!this.viewer) return;
+      // OpenSeadragon has built-in setFlip for horizontal flip
+      this.viewer.viewport.setFlip(this.flipHorizontal);
+      
+      // Vertical flip = horizontal flip + 180° rotation
+      // We combine the user's desired rotation with vertical flip
+      if (this.flipVertical) {
+        // To achieve vertical flip: flip horizontally + rotate 180°
+        // But we need to keep user's rotation in mind
+        const effectiveRotation = (this.rotationAngle + 180) % 360;
+        this.viewer.viewport.setFlip(!this.flipHorizontal);
+        this.viewer.viewport.setRotation(effectiveRotation);
+      } else {
+        this.viewer.viewport.setFlip(this.flipHorizontal);
+        this.viewer.viewport.setRotation(this.rotationAngle);
+      }
+    },
+    resetTransform() {
+      this.rotationAngle = 0;
+      this.flipHorizontal = false;
+      this.flipVertical = false;
+      if (this.viewer) {
+        this.viewer.viewport.setRotation(0);
+        this.viewer.viewport.setFlip(false);
+      }
+    },
+    // --- END ROTATION & FLIP METHODS ---
     addOverlay(x, y, number, text = "") {
       const overlayElement = document.createElement("div");
       overlayElement.className = "overlay-" + number;
-
       const displayText = text || number;
-
       overlayElement.style.cssText = "display: flex; align-items: center; color: white;";
       overlayElement.innerHTML = `
         <span style="font-size: 1em; background-color: rgba(0, 0, 0, 0.5); padding: 4px; border-radius: 4px;">${displayText}</span>
         <span style="font-size: 2em; margin-left: 4px;">&rarr;</span>
       `;
-
       this.viewer.addOverlay({
         element: overlayElement,
         location: new OpenSeadragon.Point(x, y),
         placement: OpenSeadragon.Placement.RIGHT
       });
-
       new OpenSeadragon.MouseTracker({
         element: overlayElement,
         clickHandler: (event) => {
           event.originalEvent.preventDefault();
           console.log(event);
           console.log('Overlay clicked');
-          // Add your custom logic for handling the click event on the overlay here
         },
       }).setTracking(true);
     },
-
     handleFileUpload(event) {
       const file = event.target.files[0];
       if (!file) return;
       
       this.selectedFile = file;
       
-      // Parse the CSV file
       const reader = new FileReader();
       reader.onload = (e) => {
         try {
@@ -715,135 +766,119 @@ export default {
     },
     
     processCSV(csvContent, fileName) {
-  // Simple CSV parsing
-  const lines = csvContent.split('\n');
-  const headers = lines[0].split(',');
-  
-  // Expected headers: x, y, description (optional)
-  const xIndex = headers.findIndex(h => h.toLowerCase().trim() === 'x');
-  const yIndex = headers.findIndex(h => h.toLowerCase().trim() === 'y');
-  const labelIndex = headers.findIndex(h => h.toLowerCase().trim() === 'label' || h.toLowerCase().trim() === 'description');
-  
-  if (xIndex === -1 || yIndex === -1) {
-    alert("CSV file must contain columns for 'x' and 'y' coordinates");
-    return;
-  }
-  
-  // Collect all unique labels and assign colors
-  const uniqueLabels = new Set();
-  for (let i = 1; i < lines.length; i++) {
-    if (!lines[i].trim()) continue;
-    const values = lines[i].split(',');
-    if (labelIndex !== -1 && values[labelIndex]) {
-      uniqueLabels.add(values[labelIndex].trim());
-    }
-  }
-  
-  // Generate a color map for each unique label
-  const colorMap = this.generateColorMap(Array.from(uniqueLabels));
-  
-  const pointOverlays = [];
-  
-  // Check coordinate scale - find max values
-  let maxX = 0, maxY = 0;
-  for (let i = 1; i < lines.length; i++) {
-    if (!lines[i].trim()) continue;
-    const values = lines[i].split(',');
-    const x = parseFloat(values[xIndex]);
-    const y = parseFloat(values[yIndex]);
-    if (!isNaN(x) && !isNaN(y)) {
-      maxX = Math.max(maxX, x);
-      maxY = Math.max(maxY, y);
-    }
-  }
-  
-  console.log(`Coordinate ranges - X: 0-${maxX}, Y: 0-${maxY}`);
-  
-  // Determine if coordinates are already normalized (0-1 range)
-  const isNormalized = maxX <= 1 && maxY <= 1;
-  console.log(`Coordinates are ${isNormalized ? 'already normalized' : 'in pixel space'}`);
-  
-  // Get image dimensions if needed
-  let imageWidth = 1, imageHeight = 1;
-  if (!isNormalized) {
-    if (!this.viewer || this.viewer.world.getItemCount() === 0) {
-      alert("Cannot normalize coordinates: No image is currently loaded.");
-      return;
-    }
-    imageWidth = this.viewer.world.getItemAt(0).source.dimensions.x;
-    imageHeight = this.viewer.world.getItemAt(0).source.dimensions.y;
-    console.log(`Normalizing using image dimensions: ${imageWidth}x${imageHeight}`);
-  }
-  
-  // Get the aspect ratio for OpenSeadragon viewport coordinates
-  let aspectRatio = 1;
-  if (this.viewer && this.viewer.world.getItemCount() > 0) {
-    const tiledImage = this.viewer.world.getItemAt(0);
-    aspectRatio = tiledImage.source.dimensions.x / tiledImage.source.dimensions.y;
-    console.log(`Image aspect ratio: ${aspectRatio}`);
-  }
-  
-  // Process data rows
-  for (let i = 1; i < lines.length; i++) {
-    if (!lines[i].trim()) continue;
-    
-    const values = lines[i].split(',');
-    let x = parseFloat(values[xIndex]);
-    let y = parseFloat(values[yIndex]);
-    const label = labelIndex !== -1 ? values[labelIndex].trim() : `Point ${i}`;
-    
-    if (!isNaN(x) && !isNaN(y)) {
-      // Normalize if in pixel space
-      if (!isNormalized) {
-        x = x / imageWidth;
-        y = y / imageHeight;
+      const lines = csvContent.split('\n');
+      const headers = lines[0].split(',');
+      
+      const xIndex = headers.findIndex(h => h.toLowerCase().trim() === 'x');
+      const yIndex = headers.findIndex(h => h.toLowerCase().trim() === 'y');
+      const labelIndex = headers.findIndex(h => h.toLowerCase().trim() === 'label' || h.toLowerCase().trim() === 'description');
+      
+      if (xIndex === -1 || yIndex === -1) {
+        alert("CSV file must contain columns for 'x' and 'y' coordinates");
+        return;
       }
       
-      // Convert to OpenSeadragon viewport coordinates
-      // In OSD, x ranges from 0 to 1, and y ranges from 0 to 1/aspectRatio
-      const osdX = x;
-      const osdY = y / aspectRatio;
+      const uniqueLabels = new Set();
+      for (let i = 1; i < lines.length; i++) {
+        if (!lines[i].trim()) continue;
+        const values = lines[i].split(',');
+        if (labelIndex !== -1 && values[labelIndex]) {
+          uniqueLabels.add(values[labelIndex].trim());
+        }
+      }
       
-      pointOverlays.push({
-        location: {
-          x: osdX,
-          y: osdY
-        },
-        description: label,
-        color: colorMap[label] || '#FF0000',
-      });
-    }
-  }
-  
-  console.log(`Processed ${pointOverlays.length} points`);
-  if (pointOverlays.length > 0) {
-    console.log(`First point: (${pointOverlays[0].location.x}, ${pointOverlays[0].location.y})`);
-  }
-  
-  // Add to overlay files list
-  const newOverlayFile = {
-    id: Date.now().toString(),
-    name: fileName,
-    data: pointOverlays,
-    colorMap: colorMap
-  };
-  
-  this.overlayFiles.push(newOverlayFile);
-  this.selectedOverlayFile = newOverlayFile.id;
-  this.displayPointOverlays(pointOverlays);
-},
+      const colorMap = this.generateColorMap(Array.from(uniqueLabels));
+      
+      const pointOverlays = [];
+      
+      let maxX = 0, maxY = 0;
+      for (let i = 1; i < lines.length; i++) {
+        if (!lines[i].trim()) continue;
+        const values = lines[i].split(',');
+        const x = parseFloat(values[xIndex]);
+        const y = parseFloat(values[yIndex]);
+        if (!isNaN(x) && !isNaN(y)) {
+          maxX = Math.max(maxX, x);
+          maxY = Math.max(maxY, y);
+        }
+      }
+      
+      console.log(`Coordinate ranges - X: 0-${maxX}, Y: 0-${maxY}`);
+      
+      const isNormalized = maxX <= 1 && maxY <= 1;
+      console.log(`Coordinates are ${isNormalized ? 'already normalized' : 'in pixel space'}`);
+      
+      let imageWidth = 1, imageHeight = 1;
+      if (!isNormalized) {
+        if (!this.viewer || this.viewer.world.getItemCount() === 0) {
+          alert("Cannot normalize coordinates: No image is currently loaded.");
+          return;
+        }
+        imageWidth = this.viewer.world.getItemAt(0).source.dimensions.x;
+        imageHeight = this.viewer.world.getItemAt(0).source.dimensions.y;
+        console.log(`Normalizing using image dimensions: ${imageWidth}x${imageHeight}`);
+      }
+      
+      let aspectRatio = 1;
+      if (this.viewer && this.viewer.world.getItemCount() > 0) {
+        const tiledImage = this.viewer.world.getItemAt(0);
+        aspectRatio = tiledImage.source.dimensions.x / tiledImage.source.dimensions.y;
+        console.log(`Image aspect ratio: ${aspectRatio}`);
+      }
+      
+      for (let i = 1; i < lines.length; i++) {
+        if (!lines[i].trim()) continue;
+        
+        const values = lines[i].split(',');
+        let x = parseFloat(values[xIndex]);
+        let y = parseFloat(values[yIndex]);
+        const label = labelIndex !== -1 ? values[labelIndex].trim() : `Point ${i}`;
+        
+        if (!isNaN(x) && !isNaN(y)) {
+          if (!isNormalized) {
+            x = x / imageWidth;
+            y = y / imageHeight;
+          }
+          
+          const osdX = x;
+          const osdY = y / aspectRatio;
+          
+          pointOverlays.push({
+            location: {
+              x: osdX,
+              y: osdY
+            },
+            description: label,
+            color: colorMap[label] || '#FF0000',
+          });
+        }
+      }
+      
+      console.log(`Processed ${pointOverlays.length} points`);
+      if (pointOverlays.length > 0) {
+        console.log(`First point: (${pointOverlays[0].location.x}, ${pointOverlays[0].location.y})`);
+      }
+      
+      const newOverlayFile = {
+        id: Date.now().toString(),
+        name: fileName,
+        data: pointOverlays,
+        colorMap: colorMap
+      };
+      
+      this.overlayFiles.push(newOverlayFile);
+      this.selectedOverlayFile = newOverlayFile.id;
+      this.displayPointOverlays(pointOverlays);
+    },
     
     loadSelectedOverlay() {
       if (!this.selectedOverlayFile) return;
       
-      // Find the selected overlay file
       const overlay = this.overlayFiles.find(o => o.id === this.selectedOverlayFile);
       if (!overlay) return;
       
-      // Display the point overlays without modifying the main overlay list
       this.displayPointOverlays(overlay.data);
     },
-
     applyOverlayScale() {
       const overlay = this.overlayFiles.find(o => o.id === this.selectedOverlayFile);
       if (!overlay) {
@@ -851,12 +886,9 @@ export default {
       }
       this.displayPointOverlays(overlay.data);
     },
-
     displayPointOverlays(points) {
-      // Store all point overlays for filtering later with scaling applied
       const scaleX = Number.isFinite(this.overlayScaleX) ? this.overlayScaleX : 1;
       const scaleY = Number.isFinite(this.overlayScaleY) ? this.overlayScaleY : 1;
-
       this.allPointOverlays = points.map(point => ({
         ...point,
         location: {
@@ -865,26 +897,20 @@ export default {
         },
       }));
       
-      // Clear any existing point overlays first
       this.clearPointOverlays();
-      
-      // Update based on current viewport
       this.updateVisiblePoints();
     },
     
     updateVisiblePoints() {
-      // Clear existing overlays
       this.clearPointOverlays();
       
       if (!this.allPointOverlays || !this.allPointOverlays.length || !this.viewer || !this.showPointOverlays) {
         return;
       }
       
-      // Get current viewport information
       const viewportBounds = this.viewer.viewport.getBounds();
       const zoom = this.viewer.viewport.getZoom();
       
-      // Filter points to only those in the current viewport
       const pointsInViewport = this.allPointOverlays.filter(point => {
         return (
           point.location.x >= viewportBounds.x && 
@@ -894,7 +920,6 @@ export default {
         );
       });
       
-      // If there are too many points, sample them
       let pointsToShow = pointsInViewport;
       if (pointsInViewport.length > this.maxVisiblePoints) {
         const step = Math.floor(pointsInViewport.length / this.maxVisiblePoints);
@@ -902,7 +927,6 @@ export default {
         console.log(`Sampling overlay points: showing ${pointsToShow.length} out of ${pointsInViewport.length} in viewport`);
       }
       
-      // Add the visible overlays
       this.currentPointOverlays = [];
       for (let i = 0; i < pointsToShow.length; i++) {
         const point = pointsToShow[i];
@@ -917,9 +941,7 @@ export default {
       
       console.log(`Displaying ${pointsToShow.length} points out of ${this.allPointOverlays.length} total points`);
     },
-
     clearPointOverlays() {
-      // Clear all overlays that have the point-overlay class
       const overlays = document.querySelectorAll('.point-overlay');
       overlays.forEach(overlay => {
         if (overlay.parentElement) {
@@ -932,7 +954,6 @@ export default {
       const overlayElement = document.createElement("div");
       overlayElement.className = "point-overlay";
       
-      // Create a dot with the assigned color
       overlayElement.style.cssText = "display: flex; align-items: center;";
       overlayElement.innerHTML = `
         <div style="
@@ -953,14 +974,11 @@ export default {
           display: none;
         ">${label}</span>
       `;
-
       this.viewer.addOverlay({
         element: overlayElement,
         location: new OpenSeadragon.Point(x, y),
         placement: OpenSeadragon.Placement.CENTER
       });
-
-      // Add hover effect to show label text
       overlayElement.addEventListener("mouseenter", () => {
         overlayElement.querySelector("span").style.display = "inline";
       });
@@ -969,11 +987,9 @@ export default {
         overlayElement.querySelector("span").style.display = "none";
       });
     },
-
     generateColorMap(labels) {
       const colorMap = {};
       
-      // Predefined vivid colors for better visibility
       const colors = [
         '#FF0000', '#00FF00', '#0000FF', '#FFFF00', '#FF00FF', '#00FFFF',
         '#FF8000', '#8000FF', '#0080FF', '#FF0080', '#80FF00', '#00FF80',
@@ -988,7 +1004,6 @@ export default {
       
       return colorMap;
     },
-
     togglePointOverlays() {
       this.updateVisiblePoints();
     },
@@ -998,8 +1013,6 @@ export default {
     this.loadOpenSeaDragon();
     this.locationLocal = this.$route.query.location ? this.$route.query.location : "public";
     this.loadSampleSheet(this.$route.query.sample);
-
-    // trigger reload of overlays when changing pages
     if(this.currentSlideLocal) {
       this.viewer.open(this.currentSlideLocal);
       for (let i = 0; i < this.overlaysLocal.length; i++) {
@@ -1009,7 +1022,6 @@ export default {
   },
 }
 </script>
-
 <style>
 div#view {
   flex: 1;
@@ -1019,17 +1031,14 @@ div#view {
   height: 100vh;
   width: 100vw;
 }
-
 .icon {
     width: 24px;
     height: 24px;
     color: #d8d8d8;
 }
-
 #hud {
   z-index: 1000;
 }
-
 #minimized-menu {
   z-index: 1000;
   position: fixed;
@@ -1039,7 +1048,6 @@ div#view {
   max-height: 10vh;
   overflow-y: auto;
 }
-
 #navigation-menu {
   z-index: 1000;
   position: fixed;

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -5,6 +5,8 @@ import math
 from io import BytesIO
 from typing import Dict, List, Tuple
 import threading
+import time
+from concurrent.futures import ThreadPoolExecutor, as_completed
 
 import cv2
 import numpy as np
@@ -209,17 +211,30 @@ class OmeTiffPyramid:
         if level < 0 or level > self.max_level:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid level")
 
+        # Select the appropriate pyramid level
+        # Calculate how many levels down we need to go
+        level_downscale = self.max_level - level
+        
+        # Find the best matching pyramid level
+        # Each pyramid level is typically 2x smaller than the previous
+        pyramid_level_idx = min(level_downscale // 1, len(self.levels) - 1)
+        level_arr = self.levels[pyramid_level_idx]
+        
+        # Calculate the actual scale factor for this pyramid level
+        # If we have multiple pyramid levels, each is typically 2x smaller
+        pyramid_scale = 2 ** pyramid_level_idx
+        
+        # Adjust coordinates for the selected pyramid level
         scale = 2 ** (self.max_level - level)
-        x0 = tile_x * self.tile_size * scale
-        y0 = tile_y * self.tile_size * scale
-        x1 = min(self.width, x0 + self.tile_size * scale)
-        y1 = min(self.height, y0 + self.tile_size * scale)
+        x0 = tile_x * self.tile_size * scale // pyramid_scale
+        y0 = tile_y * self.tile_size * scale // pyramid_scale
+        x1 = min(level_arr.shape[self.x_axis], x0 + (self.tile_size * scale // pyramid_scale))
+        y1 = min(level_arr.shape[self.y_axis], y0 + (self.tile_size * scale // pyramid_scale))
 
-        if x0 >= self.width or y0 >= self.height:
+        if x0 >= level_arr.shape[self.x_axis] or y0 >= level_arr.shape[self.y_axis]:
             raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tile out of bounds")
 
         with self._lock:
-            level_arr = self.levels[0]  # always slice highest resolution; downscale locally
             patches = []
             if self.channel_axis is None:
                 # Grayscale data
@@ -316,44 +331,215 @@ app.mount("/assets", StaticFiles(directory=os.path.join(client_dir, "assets")), 
 app.mount("/images", StaticFiles(directory=os.path.join(client_dir, "images")), name="images")
 
 
+def get_metadata_json_path(tiff_path: str) -> str:
+    """
+    Get the path to the metadata.json file for a given OME-TIFF file.
+    Follows the same pattern as .sample.json files.
+    """
+    # Get the directory and base filename
+    dir_path = os.path.dirname(tiff_path)
+    filename = os.path.basename(tiff_path)
+    
+    # Remove .ome.tif or .ome.tiff extension to get base name
+    if filename.lower().endswith('.ome.tiff'):
+        base_name = filename[:-9]  # Remove '.ome.tiff'
+    elif filename.lower().endswith('.ome.tif'):
+        base_name = filename[:-8]  # Remove '.ome.tif'
+    else:
+        base_name = filename
+    
+    # Return path following same pattern as .sample.json
+    return os.path.join(dir_path, f"{base_name}.metadata.json")
+
+
+def load_metadata_from_cache(tiff_path: str) -> dict:
+    """
+    Load metadata from .metadata.json cache file if it exists.
+    Returns None if cache doesn't exist or is invalid.
+    """
+    metadata_path = get_metadata_json_path(tiff_path)
+    if not os.path.exists(metadata_path):
+        return None
+    
+    try:
+        with open(metadata_path, 'r') as f:
+            metadata = json.load(f)
+        # Verify the cache is for the same file by checking file modification time
+        tiff_mtime = os.path.getmtime(tiff_path)
+        if 'file_mtime' in metadata and metadata['file_mtime'] == tiff_mtime:
+            return metadata.get('metadata', metadata)  # Support both formats
+        else:
+            # Cache is stale, return None to regenerate
+            return None
+    except (json.JSONDecodeError, IOError, OSError) as e:
+        print(f"Error reading metadata cache {metadata_path}: {e}")
+        return None
+
+
+def save_metadata_to_cache(tiff_path: str, metadata: dict):
+    """
+    Save metadata to .metadata.json cache file.
+    Follows the same pattern as .sample.json files.
+    """
+    metadata_path = get_metadata_json_path(tiff_path)
+    try:
+        # Include file modification time for cache validation
+        cache_data = {
+            'file_mtime': os.path.getmtime(tiff_path),
+            'metadata': metadata
+        }
+        with open(metadata_path, 'w') as f:
+            json.dump(cache_data, f, indent=2)
+    except (IOError, OSError) as e:
+        print(f"Error saving metadata cache {metadata_path}: {e}")
+
+
+def extract_metadata_lightweight(path: str) -> dict:
+    """
+    Extract minimal metadata from OME-TIFF without loading full pyramid.
+    Much faster than creating OmeTiffPyramid for file listing.
+    """
+    try:
+        with tifffile.TiffFile(path) as tiff:
+            series = tiff.series[0]
+            axes = series.axes
+            
+            # Get shape from series (doesn't load data)
+            shape = series.shape
+            axes_list = list(axes)
+            
+            # Determine axis indices
+            channel_axis = axes_list.index("C") if "C" in axes_list else None
+            y_axis = axes_list.index("Y")
+            x_axis = axes_list.index("X")
+            
+            # Extract dimensions
+            height = shape[y_axis]
+            width = shape[x_axis]
+            channel_count = shape[channel_axis] if channel_axis is not None else 1
+            dtype = series.dtype
+            
+            # Extract channel info from OME-XML
+            channel_info = extract_channel_info(tiff, channel_count)
+            
+            return {
+                "axes": axes,
+                "shape": [height, width],
+                "dtype": str(dtype),
+                "channels": channel_count,
+                "channel_info": channel_info,
+            }
+    except Exception as e:
+        raise ValueError(f"Failed to read metadata from {os.path.basename(path)}: {e}")
+
+
+def get_metadata_for_file(tiff_path: str, use_cache: bool = True) -> dict:
+    """
+    Get metadata for an OME-TIFF file, using cache if available.
+    
+    Args:
+        tiff_path: Path to the OME-TIFF file
+        use_cache: If True, use cached metadata if available and valid
+    
+    Returns:
+        Dictionary containing metadata
+    """
+    # Try to load from cache first
+    if use_cache:
+        cached_metadata = load_metadata_from_cache(tiff_path)
+        if cached_metadata is not None:
+            return cached_metadata
+    
+    # Generate metadata from file
+    metadata = extract_metadata_lightweight(tiff_path)
+    
+    # Save to cache
+    if use_cache:
+        save_metadata_to_cache(tiff_path, metadata)
+    
+    return metadata
+
+
+def generate_metadata_for_new_file(tiff_path: str):
+    """
+    Generate and save metadata.json for a newly added OME-TIFF file.
+    This can be called when a new file is detected.
+    Creates {name}.metadata.json next to the OME-TIFF file.
+    """
+    if not os.path.exists(tiff_path):
+        raise FileNotFoundError(f"File not found: {tiff_path}")
+    
+    if not (tiff_path.lower().endswith('.ome.tif') or tiff_path.lower().endswith('.ome.tiff')):
+        raise ValueError(f"File is not an OME-TIFF: {tiff_path}")
+    
+    try:
+        metadata = extract_metadata_lightweight(tiff_path)
+        save_metadata_to_cache(tiff_path, metadata)
+        print(f"Generated metadata cache for {os.path.basename(tiff_path)}")
+    except Exception as e:
+        print(f"Failed to generate metadata for {tiff_path}: {e}")
+        raise
+
+
+def _process_single_file(entry: os.DirEntry, base_dir: str) -> dict:
+    """
+    Process a single OME-TIFF file and return dataset info.
+    Used as a worker function for parallel processing.
+    """
+    try:
+        # Use cached metadata if available
+        metadata = get_metadata_for_file(entry.path, use_cache=True)
+        
+        dataset_info = {
+            "name": entry.name.rsplit(".ome", 1)[0],
+            "details": {},
+            "metadata": [metadata],
+        }
+        
+        # Load .sample.json if it exists (same pattern as metadata.json)
+        sample_json_path = os.path.join(base_dir, f"{dataset_info['name']}.sample.json")
+        if os.path.exists(sample_json_path):
+            with open(sample_json_path, "r") as f:
+                dataset_info["details"] = json.load(f)
+        
+        return dataset_info
+    except Exception as e:
+        print(f"Error loading {entry.path}: {e}")
+        return None
+
+
 def find_ome_tiffs(base_dir: str) -> list:
     """
     Finds all OME-TIFF files in base_dir at depth 1.
+    Uses lightweight metadata extraction with parallel processing and caching.
+    Metadata is cached in {name}.metadata.json files, same pattern as .sample.json
     """
     ome_files = []
 
     if not os.path.exists(base_dir):
         return []
 
-    with os.scandir(base_dir) as entries:
-        for entry in entries:
+    # Collect all OME-TIFF files first
+    entries = []
+    with os.scandir(base_dir) as dir_entries:
+        for entry in dir_entries:
             if entry.is_file() and (entry.name.lower().endswith(".ome.tif") or entry.name.lower().endswith(".ome.tiff")):
-                try:
-                    pyramid = tile_cache.get(entry.path)
-                    channel_count = pyramid.levels[0].shape[pyramid.channel_axis] if pyramid.channel_axis is not None else 1
-                    channel_info = extract_channel_info(pyramid.tiff, channel_count)
-
-                    dataset_info = {
-                        "name": entry.name.rsplit(".ome", 1)[0],
-                        "details": {},
-                        # Keep metadata as list to match client expectations (metadata[0])
-                        "metadata": [{
-                            "axes": pyramid.axes,
-                            "shape": [pyramid.height, pyramid.width],
-                            "dtype": str(pyramid.dtype),
-                            "channels": channel_count,
-                            "channel_info": channel_info,
-                        }],
-                    }
-                    sample_json_path = os.path.join(base_dir, f"{dataset_info['name']}.sample.json")
-                    if os.path.exists(sample_json_path):
-                        with open(sample_json_path, "r") as f:
-                            dataset_info["details"] = json.load(f)
-                    ome_files.append(dataset_info)
-                except Exception as e:
-                    # Skip problematic files but continue listing others
-                    print(f"Error loading {entry.path}: {e}")
-                    continue
+                entries.append(entry)
+    
+    # Process files in parallel
+    # Use max_workers=None to use min(32, num_files) workers
+    with ThreadPoolExecutor(max_workers=None) as executor:
+        # Submit all tasks
+        future_to_entry = {
+            executor.submit(_process_single_file, entry, base_dir): entry 
+            for entry in entries
+        }
+        
+        # Collect results as they complete
+        for future in as_completed(future_to_entry):
+            result = future.result()
+            if result is not None:
+                ome_files.append(result)
 
     return ome_files
 
@@ -383,8 +569,12 @@ async def get_dzi(
     if not os.path.exists(path_to_tiff):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OME-TIFF not found")
 
+    # print('start loading tile_cache')
     pyramid = tile_cache.get(path_to_tiff)
+    # print('done loading tile_cache')
+    # print('start getting content')
     dzi_content = pyramid.dzi_xml()
+    # print('done getting content for dzi')
     return Response(content=dzi_content, media_type="application/xml", status_code=200)
 
 
@@ -405,17 +595,28 @@ async def get_tile(
         path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tif")
     if not os.path.exists(path_to_tiff):
         raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OME-TIFF not found")
-
+    
+    # print('start loading tile_cache')
     pyramid = tile_cache.get(path_to_tiff)
+    # print('done loading tile_cache')
 
     channels = [int(x) for x in chs.split(";") if x != ""]
     colors_list = [c for c in colors.split(";") if c != ""]
     gains_list = [float(x) for x in gains.split(";") if x != ""]
 
+    # start_time = time.time()
+    # print('start getting tile')
     tile = pyramid.get_tile(level, loc_x, loc_y, channels, colors_list, gains_list, rgb)
+    # print('done getting tile')
+    # end_time = time.time()
+    # print(f'time taken: {end_time - start_time} seconds')
+
+    # print('convert tile')
     tile_rgb = cv2.cvtColor(tile, cv2.COLOR_BGR2RGB)
     img_bytes = cv2.imencode(".jpeg", tile_rgb)[1].tobytes()
     img_io = BytesIO(img_bytes)
+    # print('done converting tile')
+
     return Response(content=img_io.getvalue(), media_type="image/jpeg")
 
 

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -1,0 +1,435 @@
+import pathlib
+import os
+import json
+import math
+from io import BytesIO
+from typing import Dict, List, Tuple
+import threading
+
+import cv2
+import numpy as np
+import tifffile
+import zarr
+
+from fastapi import FastAPI, Request, HTTPException, Path, status, Query, UploadFile, Form, File, Body
+from fastapi.responses import FileResponse, JSONResponse, Response, PlainTextResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.middleware.cors import CORSMiddleware
+
+import uvicorn
+import argparse
+import xml.etree.ElementTree as ET
+
+
+class Settings:
+    SLIDE_DIR: str = "/Users/vanijzen/Developer/tissuemap/feature-overlay/example-data"
+    TMP_DIR: str = "/tmp"
+    SAVE: bool = True
+    COLORS: list = ["red", "green", "blue", "yellow", "magenta", "cyan", "white"]
+
+
+settings = Settings()
+
+
+# Simple color map for channel compositing (BGR order for OpenCV)
+COLOR_MAP: Dict[str, Tuple[int, int, int]] = {
+    "red": (0, 0, 255),
+    "green": (0, 255, 0),
+    "blue": (255, 0, 0),
+    "yellow": (0, 255, 255),
+    "magenta": (255, 0, 255),
+    "cyan": (255, 255, 0),
+    "white": (255, 255, 255),
+}
+
+
+def get_color(name: str) -> Tuple[int, int, int]:
+    return COLOR_MAP.get(name.lower(), COLOR_MAP["white"])
+
+
+OME_NS = {"ome": "http://www.openmicroscopy.org/Schemas/OME/2016-06"}
+
+
+def extract_channel_info(tiff_file: tifffile.TiffFile, channel_count: int):
+    """
+    Return list of {channel_name, channel_number} using OME-XML metadata.
+    Falls back to generic names if metadata is missing or incomplete.
+    """
+    try:
+        ome_xml = tiff_file.ome_metadata
+        if not ome_xml:
+            raise ValueError("No OME metadata")
+
+        root = ET.fromstring(ome_xml)
+        channels = []
+        for idx, ch in enumerate(root.findall(".//ome:Channel", OME_NS)):
+            name = ch.get("Name") or ch.get("ID") or f"Channel {idx}"
+            channels.append({"channel_name": name, "channel_number": idx})
+
+        # If XML exists but no channels found, synthesize based on count
+        if not channels:
+            channels = [{"channel_name": f"Channel {i}", "channel_number": i} for i in range(channel_count)]
+
+        return channels
+    except Exception:
+        # Robust fallback when parsing fails
+        return [{"channel_name": f"Channel {i}", "channel_number": i} for i in range(channel_count)]
+
+
+class OmeTiffPyramid:
+    """
+    Lazy loader for OME-TIFF using tifffile + zarr with basic pyramid math for DZI tiles.
+    """
+
+    def __init__(self, path: str, tile_size: int = 256):
+        self.path = path
+        self.tile_size = tile_size
+        self._lock = threading.Lock()
+
+        self.tiff = tifffile.TiffFile(path)
+        self.series = self.tiff.series[0]
+        self.axes = self.series.axes  # e.g., "CYX"
+
+        store = self.series.aszarr()
+        root = zarr.open(store, mode="r")
+
+        if isinstance(root, zarr.Array):
+            self.levels = [root]
+        else:
+            arrays = [v for _, v in root.items() if isinstance(v, zarr.Array)]
+            # Sort by resolution (largest first based on width dimension)
+            arrays.sort(key=lambda a: a.shape[-1], reverse=True)
+            self.levels = arrays
+
+        if not self.levels:
+            raise ValueError(f"No arrays found in OME-TIFF {path}")
+
+        self.channel_axis = self.axes.index("C") if "C" in self.axes else None
+        self.y_axis = self.axes.index("Y")
+        self.x_axis = self.axes.index("X")
+
+        base_shape = self.levels[0].shape
+        self.height = base_shape[self.y_axis]
+        self.width = base_shape[self.x_axis]
+        self.dtype = self.levels[0].dtype
+        self.dtype_max = float(np.iinfo(self.dtype).max) if np.issubdtype(self.dtype, np.integer) else 1.0
+        self.max_level = math.ceil(math.log2(max(self.width, self.height)))
+
+    def close(self):
+        self.tiff.close()
+
+    def dzi_xml(self) -> str:
+        return (
+            f'<?xml version="1.0" encoding="UTF-8"?>'
+            f'<Image TileSize="{self.tile_size}" Overlap="0" Format="jpeg" xmlns="http://schemas.microsoft.com/deepzoom/2008">'
+            f'<Size Width="{self.width}" Height="{self.height}"/></Image>'
+        )
+
+    def _slice_for_region(self, channel: int, y0: int, y1: int, x0: int, x1: int):
+        slices = []
+        for ax in self.axes:
+            if ax == "C":
+                slices.append(channel)
+            elif ax == "Y":
+                slices.append(slice(y0, y1))
+            elif ax == "X":
+                slices.append(slice(x0, x1))
+            else:
+                slices.append(0)
+        return tuple(slices)
+
+    def _read_patch(self, level_arr, channel: int, y0: int, y1: int, x0: int, x1: int):
+        patch = level_arr[self._slice_for_region(channel, y0, y1, x0, x1)]
+        return np.asarray(patch)
+
+    def _downscale_to_tile(self, patch: np.ndarray) -> np.ndarray:
+        target = (self.tile_size, self.tile_size)
+        if patch.shape[-2:] == target:
+            return patch
+        return cv2.resize(patch, target, interpolation=cv2.INTER_AREA)
+
+    def _normalize(self, patch: np.ndarray) -> np.ndarray:
+        patch = patch.astype(np.float32)
+        if self.dtype_max > 0:
+            patch = patch / self.dtype_max
+        patch = np.clip(patch, 0.0, 1.0)
+        return patch
+
+    def _compose_rgb(self, patches: List[np.ndarray], colors: List[str], gains: List[float], is_rgb: bool) -> np.ndarray:
+        h, w = patches[0].shape[-2:]
+        rgb = np.zeros((h, w, 3), dtype=np.float32)
+
+        if is_rgb and len(patches) >= 3:
+            # Treat first three channels as RGB (order: R, G, B)
+            for i, channel_patch in enumerate(patches[:3]):
+                patch = self._normalize(channel_patch)
+                rgb[:, :, 2 - i] += patch * gains[i]  # convert RGB -> BGR order
+        else:
+            for patch, color_name, gain in zip(patches, colors, gains):
+                patch_norm = self._normalize(patch)
+                b, g, r = get_color(color_name)
+                rgb[:, :, 0] += patch_norm * (b / 255.0) * gain
+                rgb[:, :, 1] += patch_norm * (g / 255.0) * gain
+                rgb[:, :, 2] += patch_norm * (r / 255.0) * gain
+
+        rgb = np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
+        return rgb
+
+    def get_tile(self, level: int, tile_x: int, tile_y: int, channels: List[int], colors: List[str], gains: List[float], is_rgb: bool) -> np.ndarray:
+        if level < 0 or level > self.max_level:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid level")
+
+        scale = 2 ** (self.max_level - level)
+        x0 = tile_x * self.tile_size * scale
+        y0 = tile_y * self.tile_size * scale
+        x1 = min(self.width, x0 + self.tile_size * scale)
+        y1 = min(self.height, y0 + self.tile_size * scale)
+
+        if x0 >= self.width or y0 >= self.height:
+            raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="Tile out of bounds")
+
+        with self._lock:
+            level_arr = self.levels[0]  # always slice highest resolution; downscale locally
+            patches = []
+            if self.channel_axis is None:
+                # Grayscale data
+                patch = level_arr[self._slice_for_region(0, y0, y1, x0, x1)]
+                patch = self._downscale_to_tile(np.asarray(patch))
+                patches.append(patch)
+                colors = colors or ["white"]
+                gains = gains or [1.0]
+            else:
+                for ch in channels:
+                    patch = self._read_patch(level_arr, ch, y0, y1, x0, x1)
+                    patch = np.squeeze(patch)
+                    patch = self._downscale_to_tile(patch)
+                    patches.append(patch)
+
+        if not patches:
+            raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No channels selected")
+
+        # Extend color/gain lists if they are shorter than channels
+        if len(colors) < len(patches):
+            colors = (colors + ["white"] * len(patches))[: len(patches)]
+        if len(gains) < len(patches):
+            gains = (gains + [1.0] * len(patches))[: len(patches)]
+
+        return self._compose_rgb(patches, colors, gains, is_rgb)
+
+
+class TiffCache:
+    """
+    Small LRU cache for open OME-TIFF pyramids to avoid reloading per request.
+    """
+
+    def __init__(self, max_items: int = 4):
+        self.max_items = max_items
+        self.cache: Dict[str, OmeTiffPyramid] = {}
+        self.order: List[str] = []
+        self._lock = threading.Lock()
+
+    def get(self, path: str) -> OmeTiffPyramid:
+        with self._lock:
+            if path in self.cache:
+                # refresh order
+                self.order = [p for p in self.order if p != path]
+                self.order.append(path)
+                return self.cache[path]
+
+            pyramid = OmeTiffPyramid(path)
+            self.cache[path] = pyramid
+            self.order.append(path)
+
+            if len(self.order) > self.max_items:
+                evict_path = self.order.pop(0)
+                evicted = self.cache.pop(evict_path, None)
+                if evicted:
+                    evicted.close()
+
+            return pyramid
+
+    def clear(self):
+        with self._lock:
+            for pyramid in self.cache.values():
+                pyramid.close()
+            self.cache.clear()
+            self.order.clear()
+
+
+app = FastAPI()
+
+app.add_middleware(
+    CORSMiddleware,
+    allow_origins=["*"],
+    allow_credentials=True,
+    allow_methods=["*"],
+    allow_headers=["*"],
+)
+
+current_folder = pathlib.Path(__file__).parent.resolve()
+client_dir = os.path.join(current_folder, "..", "client", "dist")
+slide_dir = pathlib.Path(settings.SLIDE_DIR)
+tile_cache = TiffCache(max_items=4)
+
+
+@app.get("/")
+async def root():
+    return FileResponse(os.path.join(client_dir, "index.html"))
+
+
+@app.get("/favicon.ico")
+async def favicon():
+    return FileResponse(os.path.join(client_dir, "favicon.ico"))
+
+
+app.mount("/assets", StaticFiles(directory=os.path.join(client_dir, "assets")), name="assets")
+app.mount("/images", StaticFiles(directory=os.path.join(client_dir, "images")), name="images")
+
+
+def find_ome_tiffs(base_dir: str) -> list:
+    """
+    Finds all OME-TIFF files in base_dir at depth 1.
+    """
+    ome_files = []
+
+    if not os.path.exists(base_dir):
+        return []
+
+    with os.scandir(base_dir) as entries:
+        for entry in entries:
+            if entry.is_file() and (entry.name.lower().endswith(".ome.tif") or entry.name.lower().endswith(".ome.tiff")):
+                try:
+                    pyramid = tile_cache.get(entry.path)
+                    channel_count = pyramid.levels[0].shape[pyramid.channel_axis] if pyramid.channel_axis is not None else 1
+                    channel_info = extract_channel_info(pyramid.tiff, channel_count)
+
+                    dataset_info = {
+                        "name": entry.name.rsplit(".ome", 1)[0],
+                        "details": {},
+                        # Keep metadata as list to match client expectations (metadata[0])
+                        "metadata": [{
+                            "axes": pyramid.axes,
+                            "shape": [pyramid.height, pyramid.width],
+                            "dtype": str(pyramid.dtype),
+                            "channels": channel_count,
+                            "channel_info": channel_info,
+                        }],
+                    }
+                    sample_json_path = os.path.join(base_dir, f"{dataset_info['name']}.sample.json")
+                    if os.path.exists(sample_json_path):
+                        with open(sample_json_path, "r") as f:
+                            dataset_info["details"] = json.load(f)
+                    ome_files.append(dataset_info)
+                except Exception:
+                    # Skip problematic files but continue listing others
+                    continue
+
+    return ome_files
+
+
+@app.get("/samples.json")
+async def samples(location: str = Query("public", description="Location to search for samples")):
+    search_dir = os.path.join(settings.SLIDE_DIR, location)
+    file_json = find_ome_tiffs(os.path.abspath(search_dir))
+
+    buf = {"samples": file_json, "save": settings.SAVE, "colors": settings.COLORS}
+    return JSONResponse(content=buf, status_code=200)
+
+
+@app.get("/{location}/{chs}/{rgb}/{colors}/{gains}/{file}.dzi")
+async def get_dzi(
+    location: str,
+    chs: str,
+    rgb: bool,
+    colors: str,
+    gains: str,
+    file: str,
+):
+    path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tiff")
+    if not os.path.exists(path_to_tiff):
+        path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tif")
+    if not os.path.exists(path_to_tiff):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OME-TIFF not found")
+
+    pyramid = tile_cache.get(path_to_tiff)
+    dzi_content = pyramid.dzi_xml()
+    return Response(content=dzi_content, media_type="application/xml", status_code=200)
+
+
+@app.get("/{location}/{chs}/{rgb}/{colors}/{gains}/{file}_files/{level}/{loc_x}_{loc_y}.jpeg")
+async def get_tile(
+    location: str,
+    chs: str,
+    rgb: bool,
+    colors: str,
+    gains: str,
+    file: str,
+    level: int,
+    loc_x: int,
+    loc_y: int,
+):
+    path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tiff")
+    if not os.path.exists(path_to_tiff):
+        path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tif")
+    if not os.path.exists(path_to_tiff):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OME-TIFF not found")
+
+    pyramid = tile_cache.get(path_to_tiff)
+
+    channels = [int(x) for x in chs.split(";") if x != ""]
+    colors_list = [c for c in colors.split(";") if c != ""]
+    gains_list = [float(x) for x in gains.split(";") if x != ""]
+
+    tile = pyramid.get_tile(level, loc_x, loc_y, channels, colors_list, gains_list, rgb)
+    tile_rgb = cv2.cvtColor(tile, cv2.COLOR_BGR2RGB)
+    img_bytes = cv2.imencode(".jpeg", tile_rgb)[1].tobytes()
+    img_io = BytesIO(img_bytes)
+    return Response(content=img_io.getvalue(), media_type="image/jpeg")
+
+
+@app.post("/save/{location}/{file}", response_class=PlainTextResponse)
+async def save_slide_settings(location: str, file: str, request: Request):
+    """
+    Save the slide settings alongside the OME-TIFF.
+    """
+    if not settings.SAVE:
+        return PlainTextResponse("SAVE BLOCKED", status_code=status.HTTP_403_FORBIDDEN)
+
+    try:
+        data = await request.json()
+    except json.JSONDecodeError:
+        raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid JSON")
+
+    file_path = slide_dir / location / f"{file}.sample.json"
+
+    with open(file_path, "w") as f:
+        json.dump(data, f)
+
+    return "OK"
+
+
+def main(host: str = "127.0.0.1", port: int = 8000, reload: bool = True):
+    """Run the OME-TIFF API server with Uvicorn."""
+    print(f"Starting OME-TIFF server at http://{host}:{port}")
+    print(f"Slide_dir: {settings.SLIDE_DIR}")
+    print(f"Save: {settings.SAVE}")
+    uvicorn.run("ome-server:app", host=host, port=port, reload=reload)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Run OME-TIFF server.")
+    parser.add_argument("--host", type=str, default="127.0.0.1", help="Host for the API server")
+    parser.add_argument("--port", type=int, default=8000, help="Port for the API server")
+    parser.add_argument("--reload", action="store_true", help="Enable automatic reload")
+    parser.add_argument("--save", action="store_true", help="Enable saving of slide settings")
+    parser.add_argument("--slide-dir", type=str, help="Directory to store slide files")
+    args = parser.parse_args()
+
+    if args.save:
+        settings.SAVE = True
+
+    if args.slide_dir:
+        settings.SLIDE_DIR = args.slide_dir
+
+    main(host=args.host, port=args.port, reload=args.reload)
+

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -22,10 +22,12 @@ import xml.etree.ElementTree as ET
 
 
 class Settings:
-    SLIDE_DIR: str = "/Users/vanijzen/Developer/tissuemap/feature-overlay/example-data"
+    SLIDE_DIR: str = os.getenv("TV_SLIDE_DIR", "/tv-store")
     TMP_DIR: str = "/tmp"
-    SAVE: bool = True
+    SAVE: bool = os.getenv("TV_SAVE", "True").lower() in ("true", "1", "yes")
     COLORS: list = ["red", "green", "blue", "yellow", "magenta", "cyan", "white"]
+    HOST: str = os.getenv("TV_HOST", "0.0.0.0")
+    PORT: int = int(os.getenv("TV_PORT", "8000"))
 
 
 settings = Settings()
@@ -331,6 +333,7 @@ def find_ome_tiffs(base_dir: str) -> list:
 @app.get("/samples.json")
 async def samples(location: str = Query("public", description="Location to search for samples")):
     search_dir = os.path.join(settings.SLIDE_DIR, location)
+    print(f"Searching for samples in {search_dir}")
     file_json = find_ome_tiffs(os.path.abspath(search_dir))
 
     buf = {"samples": file_json, "save": settings.SAVE, "colors": settings.COLORS}
@@ -418,19 +421,5 @@ def main(host: str = "127.0.0.1", port: int = 8000, reload: bool = True):
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Run OME-TIFF server.")
-    parser.add_argument("--host", type=str, default="127.0.0.1", help="Host for the API server")
-    parser.add_argument("--port", type=int, default=8000, help="Port for the API server")
-    parser.add_argument("--reload", action="store_true", help="Enable automatic reload")
-    parser.add_argument("--save", action="store_true", help="Enable saving of slide settings")
-    parser.add_argument("--slide-dir", type=str, help="Directory to store slide files")
-    args = parser.parse_args()
-
-    if args.save:
-        settings.SAVE = True
-
-    if args.slide_dir:
-        settings.SLIDE_DIR = args.slide_dir
-
-    main(host=args.host, port=args.port, reload=args.reload)
+    main(host=settings.HOST, port=settings.PORT, reload=True)
 

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -168,9 +168,10 @@ class OmeTiffPyramid:
             for patch, color_name, gain in zip(patches, colors, gains):
                 patch_norm = self._normalize(patch)
                 b, g, r = get_color(color_name)
-                rgb[:, :, 0] += patch_norm * (b / 255.0) * gain
+                # Swap R and B because COLOR_MAP is actually RGB despite comment
+                rgb[:, :, 0] += patch_norm * (r / 255.0) * gain  # R value -> B channel
                 rgb[:, :, 1] += patch_norm * (g / 255.0) * gain
-                rgb[:, :, 2] += patch_norm * (r / 255.0) * gain
+                rgb[:, :, 2] += patch_norm * (b / 255.0) * gain  # B value -> R channel
 
         rgb = np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
         return rgb
@@ -340,7 +341,7 @@ async def samples(location: str = Query("public", description="Location to searc
 async def get_dzi(
     location: str,
     chs: str,
-    rgb: bool,
+    rgb: str,  # Change to str
     colors: str,
     gains: str,
     file: str,

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -98,7 +98,34 @@ class OmeTiffPyramid:
         if isinstance(root, zarr.Array):
             self.levels = [root]
         else:
-            arrays = [v for _, v in root.items() if isinstance(v, zarr.Array)]
+            # Handle both Zarr 2.x and 3.x Group objects
+            arrays = []
+            try:
+                # Zarr 3.x: .members() returns (name, item) tuples
+                if hasattr(root, 'members'):
+                    for item in root.members():
+                        # members() returns tuples of (name, array)
+                        if isinstance(item, tuple):
+                            _, array = item
+                            if isinstance(array, zarr.Array):
+                                arrays.append(array)
+                        # In case it returns just the item directly
+                        elif isinstance(item, zarr.Array):
+                            arrays.append(item)
+                # Zarr 2.x: use .items()
+                elif hasattr(root, 'items'):
+                    for _, v in root.items():
+                        if isinstance(v, zarr.Array):
+                            arrays.append(v)
+                else:
+                    # Fallback: try direct iteration over keys
+                    for key in list(root.keys()) if hasattr(root, 'keys') else root:
+                        item = root[key]
+                        if isinstance(item, zarr.Array):
+                            arrays.append(item)
+            except Exception as e:
+                raise ValueError(f"Failed to extract arrays from Zarr group in {os.path.basename(path)}: {e}")
+            
             # Sort by resolution (largest first based on width dimension)
             arrays.sort(key=lambda a: a.shape[-1], reverse=True)
             self.levels = arrays
@@ -323,8 +350,9 @@ def find_ome_tiffs(base_dir: str) -> list:
                         with open(sample_json_path, "r") as f:
                             dataset_info["details"] = json.load(f)
                     ome_files.append(dataset_info)
-                except Exception:
+                except Exception as e:
                     # Skip problematic files but continue listing others
+                    print(f"Error loading {entry.path}: {e}")
                     continue
 
     return ome_files

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -7,9 +7,9 @@ fastapi==0.110.2
 uvicorn==0.29.0
 pydantic-settings==2.2.1
 python-multipart==0.0.9
-zarr==2.16.1
+zarr==3.1.5
 numcodecs==0.11.0
 dask==2024.3.1
-numpy==1.25.2
+numpy==1.26.4
 opencv-python==4.8.0.76
 tifffile==2025.12.12

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -12,3 +12,4 @@ numcodecs==0.11.0
 dask==2024.3.1
 numpy==1.25.2
 opencv-python==4.8.0.76
+tifffile==2025.12.12

--- a/server/run_ome_server_local.sh
+++ b/server/run_ome_server_local.sh
@@ -1,0 +1,2 @@
+export TV_SLIDE_DIR=/Users/vanijzen/Developer/tissuemap/feature-overlay/example-data
+python ome-server.py


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> **Medium Risk**
> Medium risk because this adds a new tile-serving backend (`server/ome-server.py`) with new dependencies and non-trivial image/metadata handling, plus changes to viewer rendering and persistence behavior that could affect saved slide settings and overlay positioning.
> 
> **Overview**
> Adds a new FastAPI-based `ome-server.py` to serve OME-TIFF slides directly (DZI + JPEG tiles), including an in-process LRU cache for open pyramids and a `.metadata.json` caching pipeline to speed up `samples.json` listing (parallelized metadata extraction).
> 
> Updates the client to point at port `8000`, adds a dedicated `saveChannels` action/button to persist only channel settings without overwriting other sample details, expands the gain slider range (log scale up to `30`), and enhances `slideView` with rotation/flip controls, overlay coordinate normalization/scaling controls, sample sorting, and some OpenSeadragon performance tuning.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0e000e1c9060f5323de63360d4ad400a7449043a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->