### PR TITLE
Histogram-based intensity control for channels

### DIFF
--- a/.claude/launch.json
+++ b/.claude/launch.json
@@ -1,0 +1,12 @@
+{
+  "version": "0.0.1",
+  "configurations": [
+    {
+      "name": "Frontend (Vite)",
+      "runtimeExecutable": "node",
+      "runtimeArgs": ["node_modules/.bin/vite"],
+      "cwd": "client",
+      "port": 5173
+    }
+  ]
+}

--- a/client/src/components/ChannelHistogram.vue
+++ b/client/src/components/ChannelHistogram.vue
@@ -1,0 +1,219 @@
+<template>
+  <div ref="container" class="channel-histogram w-full">
+    <div v-if="loading" class="text-xs text-gray-400 py-2">Loading...</div>
+    <template v-else>
+      <svg
+        ref="svg"
+        :width="svgWidth"
+        :height="svgHeight"
+        class="block select-none"
+        style="cursor: crosshair"
+        @mousemove.prevent="onMouseMove"
+        @mouseup="onMouseUp"
+        @mouseleave="onMouseUp"
+      >
+        <!-- histogram bars -->
+        <rect
+          v-for="(count, i) in bins"
+          :key="i"
+          :x="i * barWidth"
+          :y="svgHeight - barHeightFor(count)"
+          :width="Math.max(barWidth - 0.5, 1)"
+          :height="barHeightFor(count)"
+          :fill="displayColor"
+          opacity="0.75"
+        />
+
+        <!-- dim region left of low handle -->
+        <rect x="0" y="0" :width="lowPx" :height="svgHeight" fill="black" opacity="0.55" style="pointer-events:none" />
+        <!-- dim region right of high handle -->
+        <rect :x="highPx" y="0" :width="svgWidth - highPx" :height="svgHeight" fill="black" opacity="0.55" style="pointer-events:none" />
+
+        <!-- low handle line -->
+        <line
+          :x1="lowPx" y1="0" :x2="lowPx" :y2="svgHeight"
+          stroke="white" stroke-width="2"
+          style="cursor: ew-resize"
+          @mousedown.prevent.stop="startDrag('low', $event)"
+        />
+        <circle
+          :cx="lowPx" :cy="svgHeight * 0.5" r="5"
+          fill="white" stroke="#374151" stroke-width="1.5"
+          style="cursor: ew-resize"
+          @mousedown.prevent.stop="startDrag('low', $event)"
+        />
+
+        <!-- high handle line -->
+        <line
+          :x1="highPx" y1="0" :x2="highPx" :y2="svgHeight"
+          stroke="white" stroke-width="2"
+          style="cursor: ew-resize"
+          @mousedown.prevent.stop="startDrag('high', $event)"
+        />
+        <circle
+          :cx="highPx" :cy="svgHeight * 0.5" r="5"
+          fill="white" stroke="#374151" stroke-width="1.5"
+          style="cursor: ew-resize"
+          @mousedown.prevent.stop="startDrag('high', $event)"
+        />
+      </svg>
+
+      <!-- numeric labels -->
+      <div class="flex justify-between text-xs text-gray-400 mt-0.5 px-0.5">
+        <span>{{ (lowValue * 100).toFixed(0) }}%</span>
+        <span>{{ (highValue * 100).toFixed(0) }}%</span>
+      </div>
+    </template>
+  </div>
+</template>
+
+<script>
+import axios from 'axios';
+import { baseUrl } from '../lib/apiConnection';
+
+const NUM_BINS = 64;
+const SVG_HEIGHT = 56;
+
+const COLOR_MAP = {
+  red: '#ef4444',
+  green: '#22c55e',
+  blue: '#3b82f6',
+  yellow: '#eab308',
+  magenta: '#d946ef',
+  cyan: '#06b6d4',
+  white: '#d1d5db',
+};
+
+export default {
+  name: 'ChannelHistogram',
+  props: {
+    channelNumber: { type: Number, required: true },
+    channelColor: { type: String, default: 'white' },
+    low: { type: Number, default: 0.0 },
+    high: { type: Number, default: 1.0 },
+  },
+  emits: ['update:low', 'update:high', 'change'],
+  data() {
+    return {
+      bins: new Array(NUM_BINS).fill(0),
+      loading: true,
+      svgWidth: 200,
+      svgHeight: SVG_HEIGHT,
+      dragging: null,
+      dragSvgRect: null,
+    };
+  },
+  computed: {
+    lowValue() { return this.low ?? 0.0; },
+    highValue() { return this.high ?? 1.0; },
+    lowPx() { return this.lowValue * this.svgWidth; },
+    highPx() { return this.highValue * this.svgWidth; },
+    barWidth() { return this.svgWidth / NUM_BINS; },
+    maxCount() { return Math.max(...this.bins, 1); },
+    displayColor() { return COLOR_MAP[this.channelColor] || '#d1d5db'; },
+    storeLocation() {
+      const loc = this.$store.state.location;
+      const uid = this.$store.state.userProfile?.uid;
+      return loc === 'public' ? 'public' : (uid || 'noid');
+    },
+    storeSampleName() {
+      return this.$store.state.selectedSample?.name;
+    },
+  },
+  methods: {
+    barHeightFor(count) {
+      if (count === 0) return 0;
+      return Math.max(2, (Math.log(count + 1) / Math.log(this.maxCount + 1)) * this.svgHeight);
+    },
+    async fetchHistogram() {
+      if (!this.storeSampleName) return;
+      this.loading = true;
+      try {
+        // Fetch DZI XML to get image dimensions
+        const dziUrl = `${baseUrl}/${this.storeLocation}/${this.channelNumber}/false/white/1.0/0.0/1.0/${this.storeSampleName}.dzi`;
+        const dziResp = await axios.get(dziUrl);
+
+        // Parse width/height to choose a small level for sampling
+        const parser = new DOMParser();
+        const doc = parser.parseFromString(dziResp.data, 'application/xml');
+        const sizeEl = doc.querySelector('Size');
+        const w = parseInt(sizeEl?.getAttribute('Width') || '1024');
+        const h = parseInt(sizeEl?.getAttribute('Height') || '1024');
+        const maxLevel = Math.ceil(Math.log2(Math.max(w, h)));
+        // Target ~256px coverage: go 8 levels below max
+        const targetLevel = Math.max(0, maxLevel - 8);
+
+        // Fetch the overview tile (top-left, covers whole image at low res)
+        const tileUrl = `${baseUrl}/${this.storeLocation}/${this.channelNumber}/false/white/1.0/0.0/1.0/${this.storeSampleName}_files/${targetLevel}/0_0.jpeg`;
+        const tileResp = await axios.get(tileUrl, { responseType: 'blob' });
+
+        // Draw on offscreen canvas and read pixel data
+        const img = new Image();
+        const blobUrl = URL.createObjectURL(tileResp.data);
+        await new Promise((resolve, reject) => {
+          img.onload = resolve;
+          img.onerror = reject;
+          img.src = blobUrl;
+        });
+        URL.revokeObjectURL(blobUrl);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = img.width;
+        canvas.height = img.height;
+        canvas.getContext('2d').drawImage(img, 0, 0);
+        const { data } = canvas.getContext('2d').getImageData(0, 0, img.width, img.height);
+
+        // Count pixels into bins (use R channel — grayscale white rendering means R=G=B)
+        const counts = new Array(NUM_BINS).fill(0);
+        for (let i = 0; i < data.length; i += 4) {
+          const bin = Math.min(NUM_BINS - 1, Math.floor((data[i] / 255) * NUM_BINS));
+          counts[bin]++;
+        }
+        this.bins = counts;
+      } catch (e) {
+        console.error('ChannelHistogram: fetch failed', e);
+        this.bins = new Array(NUM_BINS).fill(1);
+      } finally {
+        this.loading = false;
+      }
+    },
+    startDrag(handle, event) {
+      this.dragging = handle;
+      this.dragSvgRect = this.$refs.svg.getBoundingClientRect();
+    },
+    onMouseMove(event) {
+      if (!this.dragging || !this.dragSvgRect) return;
+      const fraction = Math.max(0, Math.min(1, (event.clientX - this.dragSvgRect.left) / this.svgWidth));
+      if (this.dragging === 'low') {
+        const clamped = Math.min(fraction, this.highValue - 0.02);
+        this.$emit('update:low', +clamped.toFixed(4));
+        this.$emit('change');
+      } else {
+        const clamped = Math.max(fraction, this.lowValue + 0.02);
+        this.$emit('update:high', +clamped.toFixed(4));
+        this.$emit('change');
+      }
+    },
+    onMouseUp() {
+      this.dragging = null;
+      this.dragSvgRect = null;
+    },
+    updateWidth() {
+      if (this.$refs.container) {
+        const w = this.$refs.container.clientWidth;
+        if (w > 0) this.svgWidth = w;
+      }
+    },
+  },
+  mounted() {
+    this.$nextTick(() => {
+      this.updateWidth();
+      this.fetchHistogram();
+    });
+  },
+  watch: {
+    storeSampleName() { this.fetchHistogram(); },
+    channelNumber() { this.fetchHistogram(); },
+  },
+};
+</script>

--- a/client/src/store/modules/slideContent.js
+++ b/client/src/store/modules/slideContent.js
@@ -140,25 +140,31 @@ export const reloadSlide = async ({ state, commit }) => {
 
   const chList = [];
   const gainList = [];
-  const stainList = []; 
+  const stainList = [];
+  const minList = [];
+  const maxList = [];
 
   console.log("activated sample: ", state.activatedSample);
 
-  state.activatedSample.forEach((ch, index) => {
+  state.activatedSample.forEach((ch) => {
     if(ch.stain != "empty" && ch.activated) {
       stainList.push(`${ch.stain}`);
       gainList.push(`${ch.gain}`);
       chList.push(`${ch.channel_number}`);
+      minList.push(ch.low != null ? ch.low : 0.0);
+      maxList.push(ch.high != null ? ch.high : 1.0);
     }
-  }); 
+  });
 
   const chString = chList.join(";");
   const gainString = gainList.join(";");
   const stainString = stainList.join(";");
+  const minString = minList.join(";");
+  const maxString = maxList.join(";");
 
   const location = state.location == "public" ? "public" : (state.userProfile && state.userProfile.uid ? state.userProfile.uid : "noid");
 
-  let currentSlide = `${baseUrl}/${location}/${chString}/${state.currentSampleIsRGB}/${stainString}/${gainString}/${state.selectedSample.name}.dzi`;
+  let currentSlide = `${baseUrl}/${location}/${chString}/${state.currentSampleIsRGB}/${stainString}/${gainString}/${minString}/${maxString}/${state.selectedSample.name}.dzi`;
 
   commit('SET_STATE_PROPERTY', { property: "currentSlide", value: currentSlide });
 
@@ -194,15 +200,21 @@ export const loadSample = async ({ state, commit, dispatch }) => {
     selectedSampleBuf.metadata[0].channel_info.forEach((ch, index) => {
       const channelInfo = {
         channel_name: ch.channel_name ? ch.channel_name : index,
-        channel_number: index, 
+        channel_number: index,
         gain: selectedSampleBuf.details.gain && selectedSampleBuf.details.gain[index] ? selectedSampleBuf.details.gain[index] : 1,
         stain : selectedSampleBuf.details.ch_stain && selectedSampleBuf.details.ch_stain[index] ? selectedSampleBuf.details.ch_stain[index] : "empty",
         activated: true,
+        low: 0.0,
+        high: 1.0,
       }
       activatedSample.push(channelInfo);
     });
   } else {
-    activatedSample = selectedSampleBuf.details.channelsSetting;
+    activatedSample = selectedSampleBuf.details.channelsSetting.map(ch => ({
+      low: 0.0,
+      high: 1.0,
+      ...ch,
+    }));
   }
 
   console.log("activatedSample: ", activatedSample);

--- a/client/src/views/slideView.vue
+++ b/client/src/views/slideView.vue
@@ -118,9 +118,11 @@
                   <option v-for="option in colorOptions" :value="option">{{ option }}</option>
                 </select>
                 <input type="checkbox" v-model="channel.activated" @change="settingsChanged">
-                <log-slider
-                  :initial-gain="channel.gain"
-                  v-model:gain="channel.gain"
+                <channel-histogram
+                  :channel-number="channel.channel_number"
+                  :channel-color="channel.stain"
+                  v-model:low="channel.low"
+                  v-model:high="channel.high"
                   @change="settingsChanged"
                   class="flex-grow"
                 />
@@ -330,7 +332,7 @@ import OpenSeadragon from "openseadragon";
 import { mapGetters, mapActions, mapState, mapMutations } from "vuex";
 import { BeakerIcon, MinusCircleIcon, PlusCircleIcon, 
   XCircleIcon, ShareIcon } from '@heroicons/vue/24/solid'
-import LogSlider from "../components/LogSlider.vue";
+import ChannelHistogram from "../components/ChannelHistogram.vue";
 export default {
   components: {
     BeakerIcon, 
@@ -338,7 +340,7 @@ export default {
     PlusCircleIcon,
     XCircleIcon,
     ShareIcon,
-    LogSlider,
+    ChannelHistogram,
   },
   data() {
     return {

--- a/server/ome-server.py
+++ b/server/ome-server.py
@@ -179,25 +179,32 @@ class OmeTiffPyramid:
             return patch
         return cv2.resize(patch, target, interpolation=cv2.INTER_AREA)
 
-    def _normalize(self, patch: np.ndarray) -> np.ndarray:
+    def _normalize(self, patch: np.ndarray, min_val: float = 0.0, max_val: float = 1.0) -> np.ndarray:
         patch = patch.astype(np.float32)
         if self.dtype_max > 0:
             patch = patch / self.dtype_max
+        span = max_val - min_val
+        if span > 0:
+            patch = (patch - min_val) / span
         patch = np.clip(patch, 0.0, 1.0)
         return patch
 
-    def _compose_rgb(self, patches: List[np.ndarray], colors: List[str], gains: List[float], is_rgb: bool) -> np.ndarray:
+    def _compose_rgb(self, patches: List[np.ndarray], colors: List[str], gains: List[float], is_rgb: bool, mins: List[float] = None, maxs: List[float] = None) -> np.ndarray:
         h, w = patches[0].shape[-2:]
         rgb = np.zeros((h, w, 3), dtype=np.float32)
+        if mins is None:
+            mins = [0.0] * len(patches)
+        if maxs is None:
+            maxs = [1.0] * len(patches)
 
         if is_rgb and len(patches) >= 3:
             # Treat first three channels as RGB (order: R, G, B)
             for i, channel_patch in enumerate(patches[:3]):
-                patch = self._normalize(channel_patch)
+                patch = self._normalize(channel_patch, mins[i], maxs[i])
                 rgb[:, :, 2 - i] += patch * gains[i]  # convert RGB -> BGR order
         else:
-            for patch, color_name, gain in zip(patches, colors, gains):
-                patch_norm = self._normalize(patch)
+            for patch, color_name, gain, min_val, max_val in zip(patches, colors, gains, mins, maxs):
+                patch_norm = self._normalize(patch, min_val, max_val)
                 b, g, r = get_color(color_name)
                 # Swap R and B because COLOR_MAP is actually RGB despite comment
                 rgb[:, :, 0] += patch_norm * (r / 255.0) * gain  # R value -> B channel
@@ -207,7 +214,7 @@ class OmeTiffPyramid:
         rgb = np.clip(rgb * 255.0, 0, 255).astype(np.uint8)
         return rgb
 
-    def get_tile(self, level: int, tile_x: int, tile_y: int, channels: List[int], colors: List[str], gains: List[float], is_rgb: bool) -> np.ndarray:
+    def get_tile(self, level: int, tile_x: int, tile_y: int, channels: List[int], colors: List[str], gains: List[float], is_rgb: bool, mins: List[float] = None, maxs: List[float] = None) -> np.ndarray:
         if level < 0 or level > self.max_level:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="Invalid level")
 
@@ -253,13 +260,21 @@ class OmeTiffPyramid:
         if not patches:
             raise HTTPException(status_code=status.HTTP_400_BAD_REQUEST, detail="No channels selected")
 
-        # Extend color/gain lists if they are shorter than channels
+        # Extend color/gain/min/max lists if they are shorter than channels
         if len(colors) < len(patches):
             colors = (colors + ["white"] * len(patches))[: len(patches)]
         if len(gains) < len(patches):
             gains = (gains + [1.0] * len(patches))[: len(patches)]
+        if mins is None:
+            mins = [0.0] * len(patches)
+        if maxs is None:
+            maxs = [1.0] * len(patches)
+        if len(mins) < len(patches):
+            mins = (mins + [0.0] * len(patches))[: len(patches)]
+        if len(maxs) < len(patches):
+            maxs = (maxs + [1.0] * len(patches))[: len(patches)]
 
-        return self._compose_rgb(patches, colors, gains, is_rgb)
+        return self._compose_rgb(patches, colors, gains, is_rgb, mins, maxs)
 
 
 class TiffCache:
@@ -552,6 +567,57 @@ async def samples(location: str = Query("public", description="Location to searc
 
     buf = {"samples": file_json, "save": settings.SAVE, "colors": settings.COLORS}
     return JSONResponse(content=buf, status_code=200)
+
+
+@app.get("/{location}/{chs}/{rgb}/{colors}/{gains}/{mins}/{maxs}/{file}.dzi")
+async def get_dzi_windowed(
+    location: str,
+    chs: str,
+    rgb: str,
+    colors: str,
+    gains: str,
+    mins: str,
+    maxs: str,
+    file: str,
+):
+    return await get_dzi(location, chs, rgb, colors, gains, file)
+
+
+@app.get("/{location}/{chs}/{rgb}/{colors}/{gains}/{mins}/{maxs}/{file}_files/{level}/{loc_x}_{loc_y}.jpeg")
+async def get_tile_windowed(
+    location: str,
+    chs: str,
+    rgb: bool,
+    colors: str,
+    gains: str,
+    mins: str,
+    maxs: str,
+    file: str,
+    level: int,
+    loc_x: int,
+    loc_y: int,
+):
+    path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tiff")
+    if not os.path.exists(path_to_tiff):
+        path_to_tiff = os.path.join(settings.SLIDE_DIR, location, f"{file}.ome.tif")
+    if not os.path.exists(path_to_tiff):
+        raise HTTPException(status_code=status.HTTP_404_NOT_FOUND, detail="OME-TIFF not found")
+
+    pyramid = tile_cache.get(path_to_tiff)
+
+    channels = [int(x) for x in chs.split(";") if x != ""]
+    colors_list = [c for c in colors.split(";") if c != ""]
+    gains_list = [float(x) for x in gains.split(";") if x != ""]
+    mins_list = [float(x) for x in mins.split(";") if x != ""]
+    maxs_list = [float(x) for x in maxs.split(";") if x != ""]
+
+    tile = pyramid.get_tile(level, loc_x, loc_y, channels, colors_list, gains_list, rgb, mins_list, maxs_list)
+
+    tile_rgb = cv2.cvtColor(tile, cv2.COLOR_BGR2RGB)
+    img_bytes = cv2.imencode(".jpeg", tile_rgb)[1].tobytes()
+    img_io = BytesIO(img_bytes)
+
+    return Response(content=img_io.getvalue(), media_type="image/jpeg")
 
 
 @app.get("/{location}/{chs}/{rgb}/{colors}/{gains}/{file}.dzi")


### PR DESCRIPTION
## Summary

- Replaces the log-gain slider with an interactive **histogram** per channel
- Users can drag **low/high range handles** to set display thresholds — suppressing background and stretching signal
- Designed for immunofluorescence where background clipping is essential

## Changes

**Backend (`server/ome-server.py`)**
- New tile routes: `/{location}/{chs}/{rgb}/{colors}/{gains}/{mins}/{maxs}/{file}.dzi` and matching `_files/...jpeg` endpoint
- `_normalize()` now applies min/max windowing: `(pixel/dtype_max - min) / (max - min)` instead of simple gain
- Old routes kept for backward compatibility

**Frontend state (`client/src/store/modules/slideContent.js`)**
- Each channel gains `low: 0.0` and `high: 1.0` properties (defaults = full range, no clipping)
- `reloadSlide()` encodes `mins`/`maxs` into the DZI URL

**New component (`client/src/components/ChannelHistogram.vue`)**
- Fetches the lowest-resolution DZI tile for each channel (rendered as grayscale)
- Computes a 64-bin log-scale histogram from the JPEG pixel data (no backend endpoint needed)
- Renders as SVG with bars tinted in the channel color
- Two draggable handles for low/high cutoffs with dimming outside the selected range

## Test plan

- [ ] Load a slide with multiple fluorescence channels
- [ ] Verify histogram bars appear for each active channel
- [ ] Drag the low handle right — confirm dark background is suppressed (image brightens)
- [ ] Drag the high handle left — confirm bright signal is clipped/saturated
- [ ] Confirm channel color is reflected in histogram bar color
- [ ] Save channels and reload — confirm low/high values are preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)