### PR TITLE
Add optional HTTP Basic auth for public deployments

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ Point it at a file or a folder and open your browser.
 - [Command-line reference](#command-line-reference)
 - [Environment variables](#environment-variables)
 - [Configuration file](#configuration-file)
+- [Authentication](#authentication)
 - [Filename conventions](#filename-conventions)
 - [Programmatic use](#programmatic-use)
 - [Troubleshooting](#troubleshooting)
@@ -105,6 +106,8 @@ options:
       --validate        Verify every OME-TIFF, then exit.
       --no-save         Disable writing .sample.json sidecars.
       --log-level LEVEL DEBUG | INFO | WARNING | ERROR  (default INFO).
+      --auth-username U Username for HTTP Basic auth (pair with --auth-password).
+      --auth-password P Password for HTTP Basic auth (pair with --auth-username).
   -V, --version         Show version and exit.
   -h, --help            Show help and exit.
 ```
@@ -123,6 +126,8 @@ values take precedence.
 | `TV_PORT`      | Default listen port.                                |
 | `TV_SAVE`      | `false`/`0`/`no` disables sample.json writes.       |
 | `TV_LOG_LEVEL` | Default log level.                                  |
+| `TV_AUTH_USERNAME` | Username for HTTP Basic auth (see [Authentication](#authentication)). |
+| `TV_AUTH_PASSWORD` | Password for HTTP Basic auth.                  |
 
 ## Configuration file
 
@@ -138,6 +143,9 @@ colors:
   - red
   - green
   - blue
+auth:
+  username: alice
+  password: hunter2
 ```
 
 ```bash
@@ -146,6 +154,45 @@ tissueviewer --config config.yaml
 
 Precedence (highest wins): CLI flags → environment variables → YAML →
 built-in defaults.
+
+## Authentication
+
+For public deployments, TissueViewer can require a single username /
+password via HTTP Basic auth. The browser shows its native login dialog
+on first visit and remembers the credentials for the rest of the
+session.
+
+Enable it by supplying both a username and a password through any of
+the supported sources (precedence: CLI > env > YAML):
+
+```bash
+# Env vars — recommended; keeps secrets out of shell history and `ps`.
+export TV_AUTH_USERNAME=alice
+export TV_AUTH_PASSWORD=hunter2
+tissueviewer /path/to/slides
+
+# CLI flags — convenient for quick tests.
+tissueviewer /path/to/slides --auth-username alice --auth-password hunter2
+
+# YAML — see the auth: block in the example above.
+tissueviewer --config config.yaml
+```
+
+When enabled, every endpoint is gated: the Vue UI, static assets,
+samples / histogram / save APIs, DZI manifests, and tile images.
+Setting only one of the username/password is rejected at startup.
+
+**Security notes**
+
+- Basic auth sends credentials base64-encoded (not encrypted) on every
+  request. Always put TissueViewer behind HTTPS in public deployments
+  (e.g. via nginx, Caddy, or a cloud load balancer).
+- There is no logout flow other than closing the browser. If you need
+  per-user accounts, session cookies, SSO, or rate limiting, terminate
+  auth at a reverse proxy (e.g. `oauth2-proxy`, Cloudflare Access) and
+  leave TissueViewer's auth disabled.
+- If credentials are committed to a YAML file, restrict its permissions
+  (`chmod 600 config.yaml`).
 
 ## Filename conventions
 

--- a/src/tissueviewer/app.py
+++ b/src/tissueviewer/app.py
@@ -7,6 +7,7 @@ import logging
 from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 
+from .auth import make_basic_auth_middleware
 from .config import Config
 from .discovery import AppState, build_location_map
 from .formats.ome_tiff import TiffCache
@@ -53,6 +54,15 @@ def create_app(config: Config) -> FastAPI:
         allow_methods=["*"],
         allow_headers=["*"],
     )
+
+    if config.auth_enabled:
+        # Registering through the decorator API runs auth before any route
+        # is dispatched, so static assets, tiles, and APIs are all gated.
+        assert config.auth_username is not None and config.auth_password is not None
+        app.middleware("http")(
+            make_basic_auth_middleware(config.auth_username, config.auth_password)
+        )
+        logger.info("HTTP Basic auth enabled (user=%r)", config.auth_username)
 
     register_routes(app, state)
     return app

--- a/src/tissueviewer/auth.py
+++ b/src/tissueviewer/auth.py
@@ -1,0 +1,66 @@
+"""HTTP Basic authentication middleware.
+
+When enabled, every request to the FastAPI app must carry a valid
+``Authorization: Basic ...`` header matching the configured single
+username/password pair. There is no session state and no login form;
+the browser's native dialog handles the prompt.
+
+Note: Basic auth transmits credentials on every request encoded (not
+encrypted) in the header. Only deploy this behind HTTPS.
+"""
+
+from __future__ import annotations
+
+import base64
+import binascii
+import secrets
+from typing import Awaitable, Callable
+
+from starlette.requests import Request
+from starlette.responses import Response
+
+
+_REALM = "TissueViewer"
+
+
+def _challenge() -> Response:
+    return Response(
+        "Unauthorized",
+        status_code=401,
+        headers={"WWW-Authenticate": f'Basic realm="{_REALM}"'},
+    )
+
+
+def make_basic_auth_middleware(
+    username: str, password: str
+) -> Callable[[Request, Callable[[Request], Awaitable[Response]]], Awaitable[Response]]:
+    """Build a Starlette HTTP middleware enforcing Basic auth.
+
+    The closure pre-encodes the expected credentials so each request
+    only does a base64 decode and two constant-time comparisons.
+    """
+    expected_user = username.encode("utf-8")
+    expected_pass = password.encode("utf-8")
+
+    async def middleware(
+        request: Request,
+        call_next: Callable[[Request], Awaitable[Response]],
+    ) -> Response:
+        header = request.headers.get("authorization", "")
+        if header[:6].lower() == "basic ":
+            try:
+                decoded = base64.b64decode(header[6:].encode("ascii"), validate=True)
+            except (ValueError, binascii.Error):
+                return _challenge()
+            user, sep, pwd = decoded.partition(b":")
+            if sep:
+                ok_user = secrets.compare_digest(user, expected_user)
+                ok_pass = secrets.compare_digest(pwd, expected_pass)
+                if ok_user and ok_pass:
+                    return await call_next(request)
+        return _challenge()
+
+    return middleware
+
+
+__all__ = ["make_basic_auth_middleware"]

--- a/src/tissueviewer/cli.py
+++ b/src/tissueviewer/cli.py
@@ -93,6 +93,29 @@ def _build_parser() -> argparse.ArgumentParser:
         help="Logging verbosity (default INFO).",
     )
     parser.add_argument(
+        "--auth-username",
+        dest="auth_username",
+        default=None,
+        metavar="USER",
+        help=(
+            "Enable HTTP Basic auth with this username. Must be paired with "
+            "--auth-password. For public deployments, prefer the "
+            "TV_AUTH_USERNAME/TV_AUTH_PASSWORD env vars to keep credentials "
+            "out of shell history."
+        ),
+    )
+    parser.add_argument(
+        "--auth-password",
+        dest="auth_password",
+        default=None,
+        metavar="PASS",
+        help=(
+            "Password for HTTP Basic auth. Must be paired with --auth-username. "
+            "Note: this value is visible in shell history and `ps`; prefer "
+            "TV_AUTH_PASSWORD or a YAML config file with restricted permissions."
+        ),
+    )
+    parser.add_argument(
         "-V",
         "--version",
         action="version",

--- a/src/tissueviewer/config.py
+++ b/src/tissueviewer/config.py
@@ -48,6 +48,8 @@ class Config:
     colors: list[str] = field(default_factory=lambda: list(DEFAULT_COLORS))
     tile_cache_size: int = 4
     log_level: str = "INFO"
+    auth_username: Optional[str] = None
+    auth_password: Optional[str] = None
 
     # ------------------------------------------------------------------
     # Construction helpers
@@ -73,6 +75,8 @@ class Config:
             "watch",
             "tile_cache_size",
             "log_level",
+            "auth_username",
+            "auth_password",
         ):
             if name in data and data[name] is not None:
                 kwargs[name] = data[name]
@@ -83,6 +87,13 @@ class Config:
             kwargs["single_file"] = Path(data["single_file"]).expanduser()
         if "colors" in data and data["colors"] is not None:
             kwargs["colors"] = list(data["colors"])
+
+        auth_block = data.get("auth")
+        if isinstance(auth_block, Mapping):
+            if auth_block.get("username") is not None:
+                kwargs["auth_username"] = str(auth_block["username"])
+            if auth_block.get("password") is not None:
+                kwargs["auth_password"] = str(auth_block["password"])
 
         # Coerce bools that may come in as strings from YAML.
         for bool_key in ("save_enabled", "recursive", "open_browser", "watch"):
@@ -110,6 +121,11 @@ class Config:
             env_map["save_enabled"] = _to_bool(os.environ["TV_SAVE"])
         if os.getenv("TV_LOG_LEVEL"):
             env_map["log_level"] = os.environ["TV_LOG_LEVEL"]
+        if os.getenv("TV_AUTH_USERNAME"):
+            env_map["auth_username"] = os.environ["TV_AUTH_USERNAME"]
+        if os.getenv("TV_AUTH_PASSWORD") is not None:
+            # Allow empty string here so users can intentionally clear it.
+            env_map["auth_password"] = os.environ["TV_AUTH_PASSWORD"]
         return cls._from_mapping(env_map)
 
     @classmethod
@@ -146,6 +162,8 @@ class Config:
                 "open_browser",
                 "watch",
                 "log_level",
+                "auth_username",
+                "auth_password",
             ):
                 val = getattr(cli_args, attr, None)
                 if val is not None:
@@ -164,6 +182,13 @@ class Config:
                 cfg = replace(cfg, data_dir=target, single_file=None)
 
         return cfg
+
+    # ------------------------------------------------------------------
+    # Derived properties
+    # ------------------------------------------------------------------
+    @property
+    def auth_enabled(self) -> bool:
+        return self.auth_username is not None and self.auth_password is not None
 
     # ------------------------------------------------------------------
     # Validation
@@ -191,6 +216,14 @@ class Config:
 
         if not (0 < self.port < 65536):
             raise ValueError(f"Invalid port: {self.port}")
+
+        if (self.auth_username is None) != (self.auth_password is None):
+            raise ValueError(
+                "auth_username and auth_password must be set together "
+                "(or both left unset to disable authentication)."
+            )
+        if self.auth_username is not None and self.auth_username == "":
+            raise ValueError("auth_username must not be empty.")
 
 
 def _merge(base: Config, overlay: Config) -> Config:

--- a/tests/test_app_smoke.py
+++ b/tests/test_app_smoke.py
@@ -91,3 +91,66 @@ def test_histogram(client):
     body = resp.json()
     assert "bins" in body
     assert len(body["bins"]) == 64
+
+
+# ---------------------------------------------------------------------------
+# HTTP Basic auth
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def auth_client(tiny_ome_tiff: Path):
+    config = Config(
+        single_file=tiny_ome_tiff,
+        data_dir=tiny_ome_tiff.parent,
+        save_enabled=True,
+        auth_username="alice",
+        auth_password="hunter2",
+    )
+    app = create_app(config)
+    with TestClient(app) as c:
+        yield c
+
+
+def test_auth_blocks_unauthenticated_root(auth_client):
+    resp = auth_client.get("/")
+    assert resp.status_code == 401
+    assert resp.headers["www-authenticate"].lower().startswith("basic")
+
+
+def test_auth_blocks_unauthenticated_static(auth_client):
+    # Static assets should also be gated.
+    resp = auth_client.get("/favicon.ico")
+    assert resp.status_code == 401
+
+
+def test_auth_blocks_unauthenticated_api(auth_client):
+    resp = auth_client.get("/samples.json?location=public")
+    assert resp.status_code == 401
+
+
+def test_auth_rejects_wrong_password(auth_client):
+    resp = auth_client.get("/", auth=("alice", "wrong"))
+    assert resp.status_code == 401
+
+
+def test_auth_rejects_wrong_user(auth_client):
+    resp = auth_client.get("/", auth=("eve", "hunter2"))
+    assert resp.status_code == 401
+
+
+def test_auth_rejects_malformed_header(auth_client):
+    resp = auth_client.get("/", headers={"Authorization": "Basic not-base64!!"})
+    assert resp.status_code == 401
+
+
+def test_auth_accepts_correct_credentials(auth_client):
+    resp = auth_client.get("/", auth=("alice", "hunter2"))
+    assert resp.status_code == 200
+    assert '<div id="app">' in resp.text
+
+
+def test_auth_off_when_unconfigured(client):
+    # The default ``client`` fixture has no auth set; root should be public.
+    resp = client.get("/")
+    assert resp.status_code == 200

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -56,6 +56,21 @@ def test_parser_recognizes_core_flags():
     assert ns.log_level == "DEBUG"
 
 
+def test_parser_recognizes_auth_flags():
+    parser = build_parser()
+    ns = parser.parse_args(
+        [
+            "/tmp/whatever",
+            "--auth-username",
+            "alice",
+            "--auth-password",
+            "hunter2",
+        ]
+    )
+    assert ns.auth_username == "alice"
+    assert ns.auth_password == "hunter2"
+
+
 def test_validate_flag_runs(monkeypatch, data_dir, capsys):
     # ``--validate`` must run without starting the server and exit 0 here.
     rc = main([str(data_dir), "--recursive", "--validate"])

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -20,6 +20,8 @@ def _make_cli_args(**kwargs):
         "watch": None,
         "log_level": None,
         "no_save": False,
+        "auth_username": None,
+        "auth_password": None,
     }
     defaults.update(kwargs)
     return argparse.Namespace(**defaults)
@@ -123,3 +125,62 @@ def test_invalid_port():
     cfg = Config(data_dir=Path("."), port=70000)
     with pytest.raises(ValueError):
         cfg.validate()
+
+
+def test_auth_disabled_by_default():
+    cfg = Config()
+    assert cfg.auth_enabled is False
+    assert cfg.auth_username is None
+    assert cfg.auth_password is None
+
+
+def test_auth_enabled_when_both_set():
+    cfg = Config(data_dir=Path("."), auth_username="alice", auth_password="hunter2")
+    assert cfg.auth_enabled is True
+
+
+def test_auth_validation_requires_both(tmp_path: Path):
+    # data_dir is fine; we only want to trigger the auth pairing check.
+    cfg = Config(data_dir=tmp_path, auth_username="alice")
+    with pytest.raises(ValueError, match="auth_username and auth_password"):
+        cfg.validate()
+
+    cfg = Config(data_dir=tmp_path, auth_password="hunter2")
+    with pytest.raises(ValueError, match="auth_username and auth_password"):
+        cfg.validate()
+
+
+def test_auth_yaml_loading(tmp_path: Path):
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"auth": {"username": "alice", "password": "hunter2"}}
+        )
+    )
+    cfg = Config.from_yaml(path)
+    assert cfg.auth_username == "alice"
+    assert cfg.auth_password == "hunter2"
+
+
+def test_auth_env_vars(monkeypatch):
+    monkeypatch.setenv("TV_AUTH_USERNAME", "bob")
+    monkeypatch.setenv("TV_AUTH_PASSWORD", "s3cret")
+    cfg = Config.from_env()
+    assert cfg.auth_username == "bob"
+    assert cfg.auth_password == "s3cret"
+
+
+def test_auth_cli_overrides_env_and_yaml(tmp_path: Path, monkeypatch):
+    path = tmp_path / "cfg.yaml"
+    path.write_text(
+        yaml.safe_dump(
+            {"auth": {"username": "from_yaml", "password": "p_yaml"}}
+        )
+    )
+    monkeypatch.setenv("TV_AUTH_USERNAME", "from_env")
+    monkeypatch.setenv("TV_AUTH_PASSWORD", "p_env")
+    args = _make_cli_args(auth_username="from_cli", auth_password="p_cli")
+
+    cfg = Config.from_sources(cli_args=args, config_path=path, target=None)
+    assert cfg.auth_username == "from_cli"
+    assert cfg.auth_password == "p_cli"


### PR DESCRIPTION
This adds support for single username/password gate for the entire app (UI, static assets, APIs, tiles) so the viewer can be restricted as needed -- e.g. when it is exposed publicly.

Authentication is off unless both credentials are set; they can come from either

- CLI flags
- `TV_AUTH_USERNAME` and `TV_AUTH_PASSWORD` env vars
- an `auth:` block in the YAML config

Currentprecedence is CLI > env > YAML.